### PR TITLE
fix(button): set static height of buttons

### DIFF
--- a/core/scss/components/button/button.scss
+++ b/core/scss/components/button/button.scss
@@ -92,13 +92,13 @@
           $bg-active: transparent,
           $color-disabled: $button__link-color--disabled
         );
-        @include button-size($radius: 0, $padding: 0);
+        @include button-size($radius: 0, $padding: 0, $height: auto);
 
         min-width: 0;
       }
 
       &--size-none {
-        @include button-size($radius: 0, $padding: 0);
+        @include button-size($radius: 0, $padding: 0, $height: auto);
 
         min-width: 0;
       }
@@ -560,7 +560,7 @@
         $fill-active: $md-theme-70,
         $fill-disabled: $button__link-color--disabled
       );
-      @include button-size($radius: 0, $padding: 0);
+      @include button-size($radius: 0, $padding: 0, $height: auto);
 
       min-width: 0;
 
@@ -594,7 +594,7 @@
       $bg-active: transparent,
       $color-disabled: $button__link-color--disabled
     );
-    @include button-size($radius: 0, $padding: 0);
+    @include button-size($radius: 0, $padding: 0, $height: auto);
 
     min-width: 0;
   }

--- a/core/scss/components/button/button.scss
+++ b/core/scss/components/button/button.scss
@@ -16,6 +16,7 @@
   .#{$button__class} {
     @include button-base;
     @include button-size(
+      $height: rem-calc(36),
       $padding: $button__padding--36,
       $radius: $button__radius--36
     );
@@ -104,6 +105,7 @@
 
       &--28 {
         @include button-size(
+          $height: rem-calc(28),
           $padding: $button__padding--28,
           $radius: $button__radius--28,
           $font-size: $button__font-size--28,
@@ -113,6 +115,7 @@
 
       &--36 {
         @include button-size(
+          $height: rem-calc(36),
           $padding: $button__padding--36,
           $radius: $button__radius--36
         );
@@ -120,6 +123,7 @@
 
       &--40 {
         @include button-size(
+          $height: rem-calc(40),
           $padding: $button__padding--40,
           $radius: $button__radius--40
         );
@@ -128,6 +132,7 @@
       &--large,
       &--52 {
         @include button-size(
+          $height: rem-calc(52),
           $padding: $button__padding--52,
           $radius: $button__radius--52
         );

--- a/core/scss/components/button/mixins.scss
+++ b/core/scss/components/button/mixins.scss
@@ -49,6 +49,7 @@
 @mixin button-size(
   $font-size: $button__font-size,
   $full-width: false,
+  $height: false,
   $line-height: $button__line-height,
   $padding: false,
   $radius: false
@@ -58,6 +59,10 @@
 
   @if $radius {
     @include radius($radius);
+  }
+
+  @if $height {
+    height: $height;
   }
 
   @if $padding {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #86 
@stanjiawang I've added the ability to pass in the size prop to the button and it not get overwritten.  The style prop on Button can always be used to do any further modification.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
