### PR TITLE
react(buttons): Ability to append and/or prepend icons

### DIFF
--- a/react/src/lib/ActivityButton/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/ActivityButton/tests/__snapshots__/index.spec.js.snap
@@ -26,6 +26,7 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "active": false,
+      "appendIcon": null,
       "ariaLabel": "test",
       "ariaLabelledBy": "",
       "children": <Icon
@@ -56,6 +57,7 @@ ShallowWrapper {
       "large": false,
       "loading": false,
       "onClick": null,
+      "prependIcon": null,
       "removeStyle": false,
       "size": 68,
       "style": Object {},
@@ -95,6 +97,7 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "active": false,
+        "appendIcon": null,
         "ariaLabel": "test",
         "ariaLabelledBy": "",
         "children": <Icon
@@ -125,6 +128,7 @@ ShallowWrapper {
         "large": false,
         "loading": false,
         "onClick": null,
+        "prependIcon": null,
         "removeStyle": false,
         "size": 68,
         "style": Object {},

--- a/react/src/lib/Alert/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/Alert/tests/__snapshots__/index.spec.js.snap
@@ -48,6 +48,7 @@ ShallowWrapper {
         >
           <Button
             active={false}
+            appendIcon={null}
             ariaLabel=""
             ariaLabelledBy=""
             circle={true}
@@ -63,6 +64,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={null}
+            prependIcon={null}
             removeStyle={false}
             size={44}
             style={Object {}}
@@ -157,6 +159,7 @@ ShallowWrapper {
         "props": Object {
           "children": <Button
             active={false}
+            appendIcon={null}
             ariaLabel=""
             ariaLabelledBy=""
             circle={true}
@@ -172,6 +175,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={null}
+            prependIcon={null}
             removeStyle={false}
             size={44}
             style={Object {}}
@@ -203,6 +207,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "active": false,
+            "appendIcon": null,
             "ariaLabel": "",
             "ariaLabelledBy": "",
             "children": <Icon
@@ -233,6 +238,7 @@ ShallowWrapper {
             "large": false,
             "loading": false,
             "onClick": null,
+            "prependIcon": null,
             "removeStyle": false,
             "size": 44,
             "style": Object {},
@@ -299,6 +305,7 @@ ShallowWrapper {
           >
             <Button
               active={false}
+              appendIcon={null}
               ariaLabel=""
               ariaLabelledBy=""
               circle={true}
@@ -314,6 +321,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={null}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -408,6 +416,7 @@ ShallowWrapper {
           "props": Object {
             "children": <Button
               active={false}
+              appendIcon={null}
               ariaLabel=""
               ariaLabelledBy=""
               circle={true}
@@ -423,6 +432,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={null}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -454,6 +464,7 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "active": false,
+              "appendIcon": null,
               "ariaLabel": "",
               "ariaLabelledBy": "",
               "children": <Icon
@@ -484,6 +495,7 @@ ShallowWrapper {
               "large": false,
               "loading": false,
               "onClick": null,
+              "prependIcon": null,
               "removeStyle": false,
               "size": 44,
               "style": Object {},

--- a/react/src/lib/AlertCall/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/AlertCall/tests/__snapshots__/index.spec.js.snap
@@ -85,6 +85,7 @@ ShallowWrapper {
         >
           <Button
             active={false}
+            appendIcon={null}
             ariaLabel="reject call"
             ariaLabelledBy=""
             circle={true}
@@ -100,6 +101,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={null}
+            prependIcon={null}
             removeStyle={false}
             size={44}
             style={Object {}}
@@ -256,6 +258,7 @@ ShallowWrapper {
             null,
             <Button
               active={false}
+              appendIcon={null}
               ariaLabel="reject call"
               ariaLabelledBy=""
               circle={true}
@@ -271,6 +274,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={null}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -307,6 +311,7 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "active": false,
+              "appendIcon": null,
               "ariaLabel": "reject call",
               "ariaLabelledBy": "",
               "children": <Icon
@@ -337,6 +342,7 @@ ShallowWrapper {
               "large": false,
               "loading": false,
               "onClick": null,
+              "prependIcon": null,
               "removeStyle": false,
               "size": 44,
               "style": Object {},
@@ -426,6 +432,7 @@ ShallowWrapper {
           >
             <Button
               active={false}
+              appendIcon={null}
               ariaLabel="reject call"
               ariaLabelledBy=""
               circle={true}
@@ -441,6 +448,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={null}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -597,6 +605,7 @@ ShallowWrapper {
               null,
               <Button
                 active={false}
+                appendIcon={null}
                 ariaLabel="reject call"
                 ariaLabelledBy=""
                 circle={true}
@@ -612,6 +621,7 @@ ShallowWrapper {
                 large={false}
                 loading={false}
                 onClick={null}
+                prependIcon={null}
                 removeStyle={false}
                 size={44}
                 style={Object {}}
@@ -648,6 +658,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "active": false,
+                "appendIcon": null,
                 "ariaLabel": "reject call",
                 "ariaLabelledBy": "",
                 "children": <Icon
@@ -678,6 +689,7 @@ ShallowWrapper {
                 "large": false,
                 "loading": false,
                 "onClick": null,
+                "prependIcon": null,
                 "removeStyle": false,
                 "size": 44,
                 "style": Object {},

--- a/react/src/lib/AlertMeeting/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/AlertMeeting/tests/__snapshots__/index.spec.js.snap
@@ -83,6 +83,7 @@ ShallowWrapper {
         >
           <Button
             active={false}
+            appendIcon={null}
             ariaLabel="snooze"
             ariaLabelledBy=""
             circle={true}
@@ -98,6 +99,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={[Function]}
+            prependIcon={null}
             removeStyle={false}
             size={44}
             style={Object {}}
@@ -126,6 +128,7 @@ ShallowWrapper {
         >
           <Button
             active={false}
+            appendIcon={null}
             ariaLabel="close"
             ariaLabelledBy=""
             circle={true}
@@ -141,6 +144,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={null}
+            prependIcon={null}
             removeStyle={false}
             size={44}
             style={Object {}}
@@ -272,6 +276,7 @@ ShallowWrapper {
         "props": Object {
           "children": <Button
             active={false}
+            appendIcon={null}
             ariaLabel="snooze"
             ariaLabelledBy=""
             circle={true}
@@ -287,6 +292,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={[Function]}
+            prependIcon={null}
             removeStyle={false}
             size={44}
             style={Object {}}
@@ -318,6 +324,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "active": false,
+            "appendIcon": null,
             "ariaLabel": "snooze",
             "ariaLabelledBy": "",
             "children": <Icon
@@ -348,6 +355,7 @@ ShallowWrapper {
             "large": false,
             "loading": false,
             "onClick": [Function],
+            "prependIcon": null,
             "removeStyle": false,
             "size": 44,
             "style": Object {},
@@ -389,6 +397,7 @@ ShallowWrapper {
         "props": Object {
           "children": <Button
             active={false}
+            appendIcon={null}
             ariaLabel="close"
             ariaLabelledBy=""
             circle={true}
@@ -404,6 +413,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={null}
+            prependIcon={null}
             removeStyle={false}
             size={44}
             style={Object {}}
@@ -435,6 +445,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "active": false,
+            "appendIcon": null,
             "ariaLabel": "close",
             "ariaLabelledBy": "",
             "children": <Icon
@@ -465,6 +476,7 @@ ShallowWrapper {
             "large": false,
             "loading": false,
             "onClick": null,
+            "prependIcon": null,
             "removeStyle": false,
             "size": 44,
             "style": Object {},
@@ -554,6 +566,7 @@ ShallowWrapper {
           >
             <Button
               active={false}
+              appendIcon={null}
               ariaLabel="snooze"
               ariaLabelledBy=""
               circle={true}
@@ -569,6 +582,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={[Function]}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -597,6 +611,7 @@ ShallowWrapper {
           >
             <Button
               active={false}
+              appendIcon={null}
               ariaLabel="close"
               ariaLabelledBy=""
               circle={true}
@@ -612,6 +627,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={null}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -743,6 +759,7 @@ ShallowWrapper {
           "props": Object {
             "children": <Button
               active={false}
+              appendIcon={null}
               ariaLabel="snooze"
               ariaLabelledBy=""
               circle={true}
@@ -758,6 +775,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={[Function]}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -789,6 +807,7 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "active": false,
+              "appendIcon": null,
               "ariaLabel": "snooze",
               "ariaLabelledBy": "",
               "children": <Icon
@@ -819,6 +838,7 @@ ShallowWrapper {
               "large": false,
               "loading": false,
               "onClick": [Function],
+              "prependIcon": null,
               "removeStyle": false,
               "size": 44,
               "style": Object {},
@@ -860,6 +880,7 @@ ShallowWrapper {
           "props": Object {
             "children": <Button
               active={false}
+              appendIcon={null}
               ariaLabel="close"
               ariaLabelledBy=""
               circle={true}
@@ -875,6 +896,7 @@ ShallowWrapper {
               large={false}
               loading={false}
               onClick={null}
+              prependIcon={null}
               removeStyle={false}
               size={44}
               style={Object {}}
@@ -906,6 +928,7 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "active": false,
+              "appendIcon": null,
               "ariaLabel": "close",
               "ariaLabelledBy": "",
               "children": <Icon
@@ -936,6 +959,7 @@ ShallowWrapper {
               "large": false,
               "loading": false,
               "onClick": null,
+              "prependIcon": null,
               "removeStyle": false,
               "size": 44,
               "style": Object {},

--- a/react/src/lib/Button/index.js
+++ b/react/src/lib/Button/index.js
@@ -62,6 +62,7 @@ class Button extends React.Component {
       active,
       ariaLabel,
       ariaLabelledBy,
+      appendIcon,
       children,
       circle,
       className,
@@ -75,6 +76,7 @@ class Button extends React.Component {
       label,
       loading,
       large,
+      prependIcon,
       removeStyle,
       size,
       style,
@@ -98,24 +100,6 @@ class Button extends React.Component {
             : child.type && child.type.displayName === 'Icon'
         , false)
     );
-
-    const getChildren = () => {
-      return (
-        [
-          loading &&
-          <div key='child-0'>
-            <Loading />
-          </div>,
-          <span
-            className='md-button__children'
-            style={{ opacity: `${loading ? 0 : 1}` }}
-            key='child-1'
-          >
-            {children}
-          </span>
-        ]
-      );
-    };
 
     const getColor = () => {
       if (removeStyle) return false;
@@ -149,6 +133,38 @@ class Button extends React.Component {
     const checkButtonSize = () => (
       ['none', '28', '36', '40', '52', 28, 36, 40, 52].includes(size)
     );
+
+    const prependIconElement = prependIcon ? React.cloneElement(
+      prependIcon,
+      {...prependIcon.props, style:{ ...prependIcon.props.style, marginRight: `${getSize()/4}px` }},
+      [...prependIcon.children]
+    ) : null;
+
+    const appendIconElement = appendIcon ? React.cloneElement(
+      appendIcon,
+      {...appendIcon.props, style:{ ...appendIcon.props.style, marginLeft: `${getSize()/4}px` }},
+      [...appendIcon.children]
+    ) : null;
+
+    const getChildren = () => {
+      return (
+        [
+          loading &&
+          <div key='child-0'>
+            <Loading />
+          </div>,
+          <span
+            className='md-button__children'
+            style={{ opacity: `${loading ? 0 : 1}` }}
+            key='child-1'
+          >
+            {prependIconElement}
+            {children}
+            {appendIconElement}
+          </span>
+        ]
+      );
+    };
 
     const button = React.createElement(
       tag,
@@ -213,6 +229,8 @@ Button.propTypes = {
   ariaLabel: PropTypes.string,
   /** @prop ID to reference for blindness accessibility feature | '' */
   ariaLabelledBy: PropTypes.string,
+  /** @prop Icon to append to label | null */
+  appendIcon: PropTypes.element,
   /** @prop Children Nodes to Render inside Button | null */
   children: PropTypes.node.isRequired,
   /** @prop Sets circle css styling | false */
@@ -241,6 +259,8 @@ Button.propTypes = {
   loading: PropTypes.bool,
   /** @prop Handler to be called when the user taps the button | null */
   onClick: PropTypes.func,
+  /** @prop Icon to prepend to label | null */
+  prependIcon: PropTypes.element,
   /** @prop Optional prop to remove Button's default style | false */
   removeStyle: PropTypes.bool,
   /** @prop Optional string or number size prop | 36 */
@@ -257,6 +277,7 @@ Button.defaultProps = {
   active: false,
   ariaLabel: '',
   ariaLabelledBy: '',
+  appendIcon: null,
   children: null,
   circle: false,
   className: '',
@@ -271,6 +292,7 @@ Button.defaultProps = {
   large: false,
   loading: false,
   onClick: null,
+  prependIcon: null,
   removeStyle: false,
   size: 36,
   style: {},

--- a/react/src/lib/Button/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/Button/tests/__snapshots__/index.spec.js.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Button
     active={false}
+    appendIcon={null}
     ariaLabel="test"
     ariaLabelledBy=""
     circle={false}
@@ -20,6 +21,7 @@ ShallowWrapper {
     large={false}
     loading={false}
     onClick={null}
+    prependIcon={null}
     removeStyle={false}
     size={36}
     style={Object {}}
@@ -74,14 +76,22 @@ ShallowWrapper {
         "key": "child-1",
         "nodeType": "host",
         "props": Object {
-          "children": "test",
+          "children": Array [
+            null,
+            "test",
+            null,
+          ],
           "className": "md-button__children",
           "style": Object {
             "opacity": "1",
           },
         },
         "ref": null,
-        "rendered": "test",
+        "rendered": Array [
+          null,
+          "test",
+          null,
+        ],
         "type": "span",
       },
     ],
@@ -125,14 +135,22 @@ ShallowWrapper {
           "key": "child-1",
           "nodeType": "host",
           "props": Object {
-            "children": "test",
+            "children": Array [
+              null,
+              "test",
+              null,
+            ],
             "className": "md-button__children",
             "style": Object {
               "opacity": "1",
             },
           },
           "ref": null,
-          "rendered": "test",
+          "rendered": Array [
+            null,
+            "test",
+            null,
+          ],
           "type": "span",
         },
       ],

--- a/react/src/lib/Button/tests/index.spec.js
+++ b/react/src/lib/Button/tests/index.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Button, Loading } from '@momentum-ui/react';
+import { Button, Loading, Icon } from '@momentum-ui/react';
 
 describe('tests for <Button />', () => {
   it('should match SnapShot', () => {
@@ -66,6 +66,18 @@ describe('tests for <Button />', () => {
     const container = shallow(<Button children='test' label='test' containerLarge ariaLabel='test' />);
 
     expect(container.find('.md-button__container').length).toEqual(1);
+  });
+
+  it('should render prependIcon if prependIcon prop is passed', () => {
+    const container = shallow(<Button children='test' label='test' ariaLabel='test' prependIcon={<Icon name='arrow-down_16'/>}/>);
+    
+    expect(container.containsMatchingElement(<Icon name='arrow-down_16'/>));
+  });
+
+  it('should render appendIcon if appendIcon prop is passed', () => {
+    const container = shallow(<Button children='test' label='test' ariaLabel='test' appendIcon={<Icon name='arrow-down_16'/>}/>);
+    
+    expect(container.containsMatchingElement(<Icon name='arrow-down_16'/>));
   });
 
   it('should be type button by default', () => {

--- a/react/src/lib/ButtonGroup/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/ButtonGroup/tests/__snapshots__/index.spec.js.snap
@@ -17,6 +17,7 @@ ShallowWrapper {
   >
     <Button
       active={false}
+      appendIcon={null}
       ariaLabel="test"
       ariaLabelledBy=""
       circle={false}
@@ -32,6 +33,7 @@ ShallowWrapper {
       large={false}
       loading={false}
       onClick={null}
+      prependIcon={null}
       removeStyle={false}
       size={36}
       style={Object {}}
@@ -59,6 +61,7 @@ ShallowWrapper {
       "children": Array [
         <Button
           active={false}
+          appendIcon={null}
           ariaLabel="test"
           ariaLabelledBy=""
           circle={false}
@@ -74,6 +77,7 @@ ShallowWrapper {
           large={false}
           loading={false}
           onClick={null}
+          prependIcon={null}
           removeStyle={false}
           size={36}
           style={
@@ -98,6 +102,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "active": false,
+          "appendIcon": null,
           "ariaLabel": "test",
           "ariaLabelledBy": "",
           "children": "1",
@@ -114,6 +119,7 @@ ShallowWrapper {
           "large": false,
           "loading": false,
           "onClick": null,
+          "prependIcon": null,
           "removeStyle": false,
           "size": 36,
           "style": Object {
@@ -139,6 +145,7 @@ ShallowWrapper {
         "children": Array [
           <Button
             active={false}
+            appendIcon={null}
             ariaLabel="test"
             ariaLabelledBy=""
             circle={false}
@@ -154,6 +161,7 @@ ShallowWrapper {
             large={false}
             loading={false}
             onClick={null}
+            prependIcon={null}
             removeStyle={false}
             size={36}
             style={
@@ -178,6 +186,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "active": false,
+            "appendIcon": null,
             "ariaLabel": "test",
             "ariaLabelledBy": "",
             "children": "1",
@@ -194,6 +203,7 @@ ShallowWrapper {
             "large": false,
             "loading": false,
             "onClick": null,
+            "prependIcon": null,
             "removeStyle": false,
             "size": 36,
             "style": Object {

--- a/react/src/lib/CallControl/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/CallControl/tests/__snapshots__/index.spec.js.snap
@@ -29,6 +29,7 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "active": false,
+      "appendIcon": null,
       "ariaLabel": "test",
       "ariaLabelledBy": "",
       "children": <Icon
@@ -59,6 +60,7 @@ ShallowWrapper {
       "large": false,
       "loading": false,
       "onClick": null,
+      "prependIcon": null,
       "removeStyle": false,
       "size": 56,
       "style": Object {},
@@ -98,6 +100,7 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "active": false,
+        "appendIcon": null,
         "ariaLabel": "test",
         "ariaLabelledBy": "",
         "children": <Icon
@@ -128,6 +131,7 @@ ShallowWrapper {
         "large": false,
         "loading": false,
         "onClick": null,
+        "prependIcon": null,
         "removeStyle": false,
         "size": 56,
         "style": Object {},

--- a/react/src/lib/CollapseButton/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/CollapseButton/tests/__snapshots__/index.spec.js.snap
@@ -24,6 +24,7 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "active": false,
+      "appendIcon": null,
       "ariaLabel": "expand",
       "ariaLabelledBy": "",
       "children": <Icon
@@ -54,6 +55,7 @@ ShallowWrapper {
       "large": false,
       "loading": false,
       "onClick": [Function],
+      "prependIcon": null,
       "removeStyle": false,
       "size": 36,
       "style": Object {},
@@ -93,6 +95,7 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "active": false,
+        "appendIcon": null,
         "ariaLabel": "expand",
         "ariaLabelledBy": "",
         "children": <Icon
@@ -123,6 +126,7 @@ ShallowWrapper {
         "large": false,
         "loading": false,
         "onClick": [Function],
+        "prependIcon": null,
         "removeStyle": false,
         "size": 36,
         "style": Object {},

--- a/react/src/lib/DatePicker/DatePickerDay/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/DatePicker/DatePickerDay/tests/__snapshots__/index.spec.js.snap
@@ -23,6 +23,7 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "active": false,
+      "appendIcon": null,
       "aria-selected": false,
       "ariaLabel": "21",
       "ariaLabelledBy": "",
@@ -40,6 +41,7 @@ ShallowWrapper {
       "large": false,
       "loading": false,
       "onClick": [Function],
+      "prependIcon": null,
       "removeStyle": false,
       "size": 28,
       "style": Object {},
@@ -58,6 +60,7 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "active": false,
+        "appendIcon": null,
         "aria-selected": false,
         "ariaLabel": "21",
         "ariaLabelledBy": "",
@@ -75,6 +78,7 @@ ShallowWrapper {
         "large": false,
         "loading": false,
         "onClick": [Function],
+        "prependIcon": null,
         "removeStyle": false,
         "size": 28,
         "style": Object {},

--- a/react/src/lib/Select/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/Select/tests/__snapshots__/index.spec.js.snap
@@ -31,6 +31,7 @@ ShallowWrapper {
       >
         <Button
           active={false}
+          appendIcon={null}
           aria-haspopup="listbox"
           ariaLabel=""
           ariaLabelledBy="md-select-1__label"
@@ -50,6 +51,7 @@ ShallowWrapper {
           name="md-select-1"
           onClick={[Function]}
           onSelect={null}
+          prependIcon={null}
           removeStyle={false}
           size={36}
           style={Object {}}
@@ -90,6 +92,7 @@ ShallowWrapper {
         "children": Array [
           <Button
             active={false}
+            appendIcon={null}
             aria-haspopup="listbox"
             ariaLabel=""
             ariaLabelledBy="md-select-1__label"
@@ -109,6 +112,7 @@ ShallowWrapper {
             name="md-select-1"
             onClick={[Function]}
             onSelect={null}
+            prependIcon={null}
             removeStyle={false}
             size={36}
             style={Object {}}
@@ -149,6 +153,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "active": false,
+            "appendIcon": null,
             "aria-haspopup": "listbox",
             "ariaLabel": "",
             "ariaLabelledBy": "md-select-1__label",
@@ -189,6 +194,7 @@ ShallowWrapper {
             "name": "md-select-1",
             "onClick": [Function],
             "onSelect": null,
+            "prependIcon": null,
             "removeStyle": false,
             "size": 36,
             "style": Object {},
@@ -287,6 +293,7 @@ ShallowWrapper {
         >
           <Button
             active={false}
+            appendIcon={null}
             aria-haspopup="listbox"
             ariaLabel=""
             ariaLabelledBy="md-select-1__label"
@@ -306,6 +313,7 @@ ShallowWrapper {
             name="md-select-1"
             onClick={[Function]}
             onSelect={null}
+            prependIcon={null}
             removeStyle={false}
             size={36}
             style={Object {}}
@@ -346,6 +354,7 @@ ShallowWrapper {
           "children": Array [
             <Button
               active={false}
+              appendIcon={null}
               aria-haspopup="listbox"
               ariaLabel=""
               ariaLabelledBy="md-select-1__label"
@@ -365,6 +374,7 @@ ShallowWrapper {
               name="md-select-1"
               onClick={[Function]}
               onSelect={null}
+              prependIcon={null}
               removeStyle={false}
               size={36}
               style={Object {}}
@@ -405,6 +415,7 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "active": false,
+              "appendIcon": null,
               "aria-haspopup": "listbox",
               "ariaLabel": "",
               "ariaLabelledBy": "md-select-1__label",
@@ -445,6 +456,7 @@ ShallowWrapper {
               "name": "md-select-1",
               "onClick": [Function],
               "onSelect": null,
+              "prependIcon": null,
               "removeStyle": false,
               "size": 36,
               "style": Object {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ability to append and/or prepend icons
## Description
Added new props appendIcon and prependIcon to <Button /> which take in an <Icon /> element and renders it inside the button

## Related Issue
#236 

## Motivation and Context
As per Momentum Design spec

## How Has This Been Tested?
- Jest snapshot testing

## Screenshots:
![image](https://user-images.githubusercontent.com/5726047/58469414-1671a900-815d-11e9-9b4e-164da5585011.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
