### PR TITLE
fix(popover): add popoverTrigger Input

### DIFF
--- a/angular/src/lib/popover/popover.directive.ts
+++ b/angular/src/lib/popover/popover.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef,  Input, TemplateRef } from '@angular/core';
+import { Directive, ElementRef,  Input, TemplateRef, HostListener } from '@angular/core';
 import { Overlay, OverlayPositionBuilder,  ScrollStrategyOptions } from '@angular/cdk/overlay';
 
 import { TooltipDirective } from '../tooltip/tooltip.directive';
@@ -11,6 +11,9 @@ export class PopoverDirective extends TooltipDirective {
 
   /** @prop shows the arrow or not */
   @Input() showArrow: boolean  = true;
+
+  /** @prop Sets the popover trigger MouseEnter, Click or Focus - Click is default*/
+  @Input() popoverTrigger: string = 'Click';
 
   constructor(
     overlay: Overlay,
@@ -25,6 +28,52 @@ export class PopoverDirective extends TooltipDirective {
           elementRef
           );
       }
+
+
+  @HostListener('mouseenter')
+  showPopover() {
+    if ( this.popoverTrigger === 'MouseEnter') {
+      this.show();
+    }
+  }
+
+  @HostListener('mouseleave')
+  hide() {
+    if ( this.popoverTrigger === 'MouseEnter' || this.popoverTrigger === 'Click') {
+      this.close();
+    }
+  }
+
+  @HostListener('click')
+  onClick() {
+    if ( this.popoverTrigger === 'Click') {
+      this.show();
+    }
+  }
+
+  @HostListener('document:click', ['$event.target'])
+  closePopover(targetElement) {
+    if ( this.popoverTrigger === 'Click') {
+      const clickedOutside = !this.elementRef.nativeElement.contains(targetElement);
+      if (clickedOutside) {
+        this.close();
+      }
+    }
+  }
+
+  @HostListener('focus')
+  onFocus() {
+    if ( this.popoverTrigger === 'Focus') {
+      this.show();
+    }
+  }
+
+  @HostListener('focusout')
+  onFocusout() {
+    if ( this.popoverTrigger === 'Focus') {
+      this.close();
+    }
+  }
 
   public show() {
     super.show();

--- a/angular/src/lib/popover/tests/popover.component.spec.ts
+++ b/angular/src/lib/popover/tests/popover.component.spec.ts
@@ -37,7 +37,7 @@ describe('Popover Test', () => {
     fixture = TestBed.createComponent(TestPopoverComponent);
     component = fixture.componentInstance;
     testEl = fixture.debugElement.query(By.css('md-badge'));
-    testEl.triggerEventHandler('mouseenter', null);
+    testEl.triggerEventHandler('click', null);
     fixture.detectChanges();
   }));
 
@@ -45,7 +45,7 @@ describe('Popover Test', () => {
     expect(overlayContainerEl).toMatchSnapshot();
   });
 
-  it('popover should appear when hovering over badge NOTE: it uses tooltip', () => {
+  it('popover should appear when click over badge', () => {
 
     const popoverEl = overlayContainerEl.querySelector('md-tooltip');
     expect(popoverEl).not.toBeNull();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
adding popoverTrigger which was not there

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
