### PR TITLE
fix(toggle-switch): correct registerOnChange call, add setDisabledSta…

### DIFF
--- a/angular/src/lib/toggle-switch/examples/toggle-switch-default.component.ts
+++ b/angular/src/lib/toggle-switch/examples/toggle-switch-default.component.ts
@@ -14,7 +14,7 @@ import { Validators } from '@angular/forms';
     >
     </md-toggle-switch>
 
-    {{ bool }}
+    ngModel: {{ bool }}
   `,
   styles: [],
 })
@@ -24,6 +24,6 @@ export class ToggleSwitchDefaultComponent {
   constructor() {}
 
   onToggle(event) {
-    this.bool = event.checked;
+    console.info('emitter: ', event.checked);
   }
 }

--- a/angular/src/lib/toggle-switch/examples/toggle-switch-examples.module.ts
+++ b/angular/src/lib/toggle-switch/examples/toggle-switch-examples.module.ts
@@ -2,8 +2,9 @@ import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ToggleSwitchDefaultComponent } from './toggle-switch-default.component';
+import { ToggleSwitchModule } from '../toggle-switch.module';
 
-import { ToggleSwitchModule } from '@momentum-ui/angular';
+
 
 @NgModule({
   declarations: [ToggleSwitchDefaultComponent],

--- a/angular/src/lib/toggle-switch/tests/toggle-switch.component.spec.ts
+++ b/angular/src/lib/toggle-switch/tests/toggle-switch.component.spec.ts
@@ -59,6 +59,7 @@ describe('ToggleSwitchComponent', () => {
 
     fixture.whenStable().then(() => {
       expect(component.onSwitch).toHaveBeenCalled();
+      expect(toggleSwitch.checked).toBe(true);
     });
   }));
 });

--- a/angular/src/lib/toggle-switch/toggle-switch.component.ts
+++ b/angular/src/lib/toggle-switch/toggle-switch.component.ts
@@ -43,22 +43,22 @@ const CUSTOM_TOGGLE_SWITCH_VALUE_ACCESSOR: any = {
   providers: [CUSTOM_TOGGLE_SWITCH_VALUE_ACCESSOR],
 })
 export class ToggleSwitchComponent implements ControlValueAccessor {
-  /** @option Optional CSS class name | '' */
+  /** @prop Optional CSS class name | '' */
   @Input() class: string = '';
-  /** @option Sets the attribute disabled to the ToggleSwitch | false */
+  /** @prop Sets the attribute disabled to the ToggleSwitch | false */
   @Input() disabled: boolean = false;
-  /** @option Unique HTML ID used for tying label to HTML input for automated testing */
+  /** @prop Unique HTML ID used for tying label to HTML input for automated testing */
   @Input() htmlId: string = '';
-  /** @option ToggleSwitch label text | '' */
+  /** @prop ToggleSwitch label text | '' */
   @Input() label: string = '';
-  /** @option ToggleSwitch name for group | '' */
+  /** @prop ToggleSwitch name for group | '' */
   @Input() name: string = '';
-  /** @option index of the ToggleSwitch in tab order */
+  /** @prop index of the ToggleSwitch in tab order */
   @Input() tabIndex: number;
-  /** @option String value that corresponds with ToggleSwitch button | '' */
+  /** @prop String value that corresponds with ToggleSwitch button | '' */
   @Input() value: any = '';
 
-  /** @option Callback function invoked when user clicks the ToggleSwitch button | null */
+  /** @prop Callback function invoked when user clicks the ToggleSwitch button | null */
   @Output() change: EventEmitter<any> = new EventEmitter();
 
   // pass in boolean to ngModel for filled.
@@ -76,11 +76,15 @@ export class ToggleSwitchComponent implements ControlValueAccessor {
   }
 
   registerOnChange(fn: Function): void {
-    this.onSwitchTouch = fn;
+    this.onSwitchChange = fn;
   }
 
   registerOnTouched(fn: Function): void {
-    this.onSwitchChange = fn;
+    this.onSwitchTouch = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
   }
 
   onSwitch(event: Event) {
@@ -94,7 +98,7 @@ export class ToggleSwitchComponent implements ControlValueAccessor {
     this.checked = bool;
 
     this.onSwitchChange(this.checked);
-
     this.change.emit({ switchEvent: event, checked: this.checked });
+    event.stopPropagation();
   }
 }


### PR DESCRIPTION
- registerOnChange and registerOnTouch should be swapped fixing checked value;
-  add control value accessor setDisabledState,
-  emitter no longer firing undefined.  
- Update example to go off the ngModel value instead of the emitted value. 


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
