### PR TITLE
fix(z-order): import cdk overlay.scss so we can update the z-order

### DIFF
--- a/angular/src/docs/styles.scss
+++ b/angular/src/docs/styles.scss
@@ -3,6 +3,6 @@ $icon-font-path: '~@momentum-ui/icons/fonts';
 $images-path: '~@momentum-ui/core/images';
 
 @import '~@momentum-ui/core/scss/momentum-ui';
-
+// TO DO: remove this when we fix the angular ...
 @import '~@angular/cdk/overlay-prebuilt.css';
 @import '~@angular/cdk/a11y-prebuilt.css';

--- a/angular/src/lib/select/select.component.ts
+++ b/angular/src/lib/select/select.component.ts
@@ -69,7 +69,7 @@ export class SelectChange {
       [cdkConnectedOverlayOpen]="overlayOpen"
       [cdkConnectedOverlayWidth]="this.anchorWidth"
       [cdkConnectedOverlayOffsetY]="6"
-      [cdkConnectedOverlayPanelClass]="'md-event-overlay__children'"
+      [cdkConnectedOverlayPanelClass]="'md-select__dropdown'"
       [cdkConnectedOverlayHasBackdrop]="true"
       [cdkConnectedOverlayBackdropClass]="'cdk-overlay-transparent-backdrop'"
       (backdropClick)="close()"

--- a/core/scss/components/cdk-overlay/cdk-overlay.scss
+++ b/core/scss/components/cdk-overlay/cdk-overlay.scss
@@ -1,0 +1,140 @@
+// We want overlays to always appear over user content, so set a baseline
+// very high z-index for the overlay container, which is where we create the new
+// stacking context for all overlays.
+$cdk-z-index-overlay-container: 1060;
+$cdk-z-index-overlay: 1060;
+$cdk-z-index-overlay-backdrop: 1060;
+
+// Background color for all of the backdrops
+$cdk-overlay-dark-backdrop-background: $black-16;
+
+// Default backdrop animation is based on the Material Design swift-ease-out.
+$backdrop-animation-duration: 400ms !default;
+$backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
+
+
+  .cdk-overlay-container, .cdk-global-overlay-wrapper {
+    // Disable events from being captured on the overlay container.
+    pointer-events: none;
+
+    // The container should be the size of the viewport.
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
+
+  // The overlay-container is an invisible element which contains all individual overlays.
+  .cdk-overlay-container {
+    position: fixed;
+    z-index: $cdk-z-index-overlay-container;
+
+    &:empty {
+      // Hide the element when it doesn't have any child nodes. This doesn't
+      // include overlays that have been detached, rather than disposed.
+      display: none;
+    }
+  }
+
+  // We use an extra wrapper element in order to use make the overlay itself a flex item.
+  // This makes centering the overlay easy without running into the subpixel rendering
+  // problems tied to using `transform` and without interfering with the other position
+  // strategies.
+  .cdk-global-overlay-wrapper {
+    display: flex;
+    position: absolute;
+    z-index: $cdk-z-index-overlay;
+  }
+
+  // A single overlay pane.
+  .cdk-overlay-pane {
+    // Note: it's important for this one to start off `absolute`,
+    // in order for us to be able to measure it correctly.
+    position: absolute;
+    pointer-events: auto;
+    box-sizing: border-box;
+    z-index: $cdk-z-index-overlay;
+
+    // For connected-position overlays, we set `display: flex` in
+    // order to force `max-width` and `max-height` to take effect.
+    display: flex;
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .cdk-overlay-backdrop {
+    // TODO(jelbourn): reuse sidenav fullscreen mixin.
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+
+    z-index: $cdk-z-index-overlay-backdrop;
+    pointer-events: auto;
+    -webkit-tap-highlight-color: transparent;
+    transition: opacity $backdrop-animation-duration $backdrop-animation-timing-function;
+    opacity: 0;
+
+    &.cdk-overlay-backdrop-showing {
+      opacity: 1;
+
+      // In high contrast mode the rgba background will become solid so we need to fall back
+      // to making it opaque using `opacity`. Note that we can't use the `cdk-high-contrast`
+      // mixin, because we can't normalize the import path to the _a11y.scss both for the
+      // source and when this file is distributed. See #10908.
+      @media screen and (-ms-high-contrast: active) {
+        opacity: 0.6;
+      }
+    }
+  }
+
+  .cdk-overlay-dark-backdrop {
+    background: $cdk-overlay-dark-backdrop-background;
+  }
+
+  .cdk-overlay-transparent-backdrop {
+    // Note: as of Firefox 57, having the backdrop be `background: none` will prevent it from
+    // capturing the user's mouse scroll events. Since we also can't use something like
+    // `rgba(0, 0, 0, 0)`, we work around the inconsistency by not setting the background at
+    // all and using `opacity` to make the element transparent.
+    &, &.cdk-overlay-backdrop-showing {
+      opacity: 0;
+    }
+  }
+
+  // Overlay parent element used with the connected position strategy. Used to constrain the
+  // overlay element's size to fit within the viewport.
+  .cdk-overlay-connected-position-bounding-box {
+    position: absolute;
+    z-index: $cdk-z-index-overlay;
+
+    // We use `display: flex` on this element exclusively for centering connected overlays.
+    // When *not* centering, a top/left/bottom/right will be set which overrides the normal
+    // flex layout.
+    display: flex;
+
+    // We use the `column` direction here to avoid some flexbox issues in Edge
+    // when using the "grow after open" options.
+    flex-direction: column;
+
+    // Add some dimensions so the element has an `innerText` which some people depend on in tests.
+    min-width: 1px;
+    min-height: 1px;
+  }
+
+  // Used when disabling global scrolling.
+  .cdk-global-scrollblock {
+    position: fixed;
+
+    // Necessary for the content not to lose its width. Note that we're using 100%, instead of
+    // 100vw, because 100vw includes the width plus the scrollbar, whereas 100% is the width
+    // that the element had before we made it `fixed`.
+    width: 100%;
+
+    // Note: this will always add a scrollbar to whatever element it is on, which can
+    // potentially result in double scrollbars. It shouldn't be an issue, because we won't
+    // block scrolling on a page that doesn't have a scrollbar in the first place.
+    overflow-y: scroll;
+  }
+

--- a/core/scss/components/components.scss
+++ b/core/scss/components/components.scss
@@ -9,6 +9,7 @@
 @import 'button/button';
 @import 'button-group/button-group';
 @import 'card/card';
+@import 'cdk-overlay/cdk-overlay';
 @import 'checkbox/checkbox';
 @import 'chip/chip';
 @import 'close/close';

--- a/core/scss/components/select/select.scss
+++ b/core/scss/components/select/select.scss
@@ -72,7 +72,6 @@
         }
       }
     }
-
     .#{$prefix}-event-overlay__children {
       max-height: $dropdown-height;
       overflow: auto;
@@ -93,5 +92,10 @@
         border-radius: 0 0 4px 4px;
       }
     }
+  }
+  .#{$select__class}__dropdown {
+    background: $md-white-100;
+    border-radius: $event-overlay__border-radius;
+    box-shadow: $event-overlay__border, $event-overlay__shadow;
   }
 }

--- a/core/scss/momentum-ui-ng.scss
+++ b/core/scss/momentum-ui-ng.scss
@@ -100,6 +100,7 @@
 @import 'components/button/button';
 @import 'components/button-group/button-group';
 @import 'components/card/card';
+@import 'components/cdk-overlay/cdk-overlay';
 @import 'components/checkbox/checkbox';
 @import 'components/chip/chip';
 @import 'components/close/close';


### PR DESCRIPTION
z-order of the cdk was 1000 which was conflicting with several of our cmponents now it's 1060

fixing for angularjs for now .. will need to fix anguarl

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
