### PR TITLE
Fix placeholder color

### DIFF
--- a/core/scss/components/input/settings.scss
+++ b/core/scss/components/input/settings.scss
@@ -16,7 +16,7 @@ $input__line-height-message: rem-calc(16) !default;
 
 $input__font-family: $brand-font-regular !default;
 $input__font-color: $md-black-100 !default;
-$input__font-color--placeholder: $black-60 !default;
+$input__font-color--placeholder: $md-gray-70 !default;
 $input__font-color--error: $md-red-70 !default;
 $input__font-color--warning: $md-yellow-70 !default;
 $input__font-color--success: $md-green-70 !default;


### PR DESCRIPTION
## Description
The color for placeholders in various components was not correct, it was too dark and looked too much like regular text. We've had multiple complaints about this from Control Hub users. We got the color that should have been used from Paul Jeter and Kevin Smith.

## Related Issue
From discussion in Teams space:
![image](https://user-images.githubusercontent.com/1787852/64455823-e8521c80-d0ee-11e9-8e14-05204cc3273f.png)

## Motivation and Context
We looked into this based on complaints from Control Hub users who found that it looked there was already a value in an empty input, they were fooled by the dark placeholder color.

## How Has This Been Tested?
No tests for this seem to be present, but I verified that I'm using the color in the same way that other parts of the CSS are.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
