### PR TITLE
fix(datepicker,angularjs): vertical center alignment of calendar icon button + text

### DIFF
--- a/angularjs/src/lib/components/datepicker/datepicker.component.ts
+++ b/angularjs/src/lib/components/datepicker/datepicker.component.ts
@@ -338,8 +338,8 @@ export class DatePickerComponent implements ng.IComponentOptions {
   public template = `
     <div class="md-datepicker-container md-datepicker__wrapper" ng-form="$ctrl.datePickerForm">
       <button class="md-button md-button--white" ng-click="$ctrl.showCalendar($event)" ng-disabled="$ctrl.disabled" ng-class="{'md-error': $ctrl.isError}">
-        <i class="icon icon-calendar-month_24 md-datepicker__calendar-icon"></i>
-        <span>{{ $ctrl.viewValue ? $ctrl.viewValue : $ctrl.placeholder }}</span>
+        <i class="icon icon-calendar-month_24"></i>
+        <span class="md-button__text">{{ $ctrl.viewValue ? $ctrl.viewValue : $ctrl.placeholder }}</span>
         <i ng-if="$ctrl.hasClearButton()" class="icon icon-close" ng-click="$ctrl.clearDate($event)"></i>
       </button>
 

--- a/core/scss/components/date-picker/date-picker.scss
+++ b/core/scss/components/date-picker/date-picker.scss
@@ -4,6 +4,16 @@
   .#{$datepicker__class} {
     &-container {
       display: inline-flex;
+
+      > .md-button {
+        display: flex;
+        justify-content: center;
+
+        .md-button__text {
+          margin-left: 0.5rem;
+          line-height: 1.75rem;
+        }
+      }
     }
 
     &__calendar-icon {


### PR DESCRIPTION
## Description
- when using `md-datepicker` (AngularJS), the vertical alignment of the icon and text looks a bit off-centered (see "before" screenshots)

## Related Issue
- issue was discussed in "Momentum UI Q&A"

## Motivation and Context
- fixes layout issue happening in the `md-datepicker` widget by default

## How Has This Been Tested?
- manual testing in several instances of the widget used in our app

## Screenshots:
**Before** (If applicable):
- use case 1:
  ![Cisco Webex Control Hub - Google Chrome_655](https://user-images.githubusercontent.com/39541004/65794011-13db8c00-e11c-11e9-8eb4-7202fff92144.png)

- use case 2:
  ![Cisco Webex Control Hub - Google Chrome_653](https://user-images.githubusercontent.com/39541004/65794037-205fe480-e11c-11e9-9b8a-d28dea3189ca.png)

**After**:
- use case 1:
  ![Cisco Webex Control Hub - Google Chrome_656](https://user-images.githubusercontent.com/39541004/65794026-1b029a00-e11c-11e9-8252-fb6c2ec25a72.png)

- use case 2:
  ![Cisco Webex Control Hub - Google Chrome_654](https://user-images.githubusercontent.com/39541004/65794043-248c0200-e11c-11e9-8787-b8cc5c79cde1.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
