### PR TITLE
fix(list): fix focus index out of bounds

### DIFF
--- a/react/src/lib/List/index.js
+++ b/react/src/lib/List/index.js
@@ -221,9 +221,18 @@ class List extends React.Component {
     const { eventKey, label, value } = opts;
 
     const items = this.getFocusableItems();
-    const index = items.indexOf(this.listNode.querySelector(`[data-md-event-key="${eventKey}"]`));
+    const index = items.findIndex((item) => item.getAttribute('data-md-event-key') === eventKey || item.querySelector(`[data-md-event-key="${  eventKey  }"]`));
+
+    // Don't do anything if index is the same or outside of the bounds
+    if (
+      eventKey === active ||
+      index < 0 ||
+      index > items.length - 1
+    )
+    return;
 
     this.setFocus(items, index);
+  
     // Don't do anything if onSelect Event Handler is present
     if (onSelect) {
       return onSelect(e, {
@@ -232,13 +241,7 @@ class List extends React.Component {
         value,
       });
     }
-    // Don't do anything if index is the same or outside of the bounds
-    if (
-      eventKey === active ||
-      index < 0 ||
-      index > items.length - 1
-    )
-    return;
+
     // Keep reference to last index for event handler
     const last = active;
     // Call change event handler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
List is causing a crash when opening the list through a button. If the index of the focus is not found, then it tries to call `attribute` on a null object and crash. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this with the Teams Web Client.

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
