### PR TITLE
fix(react/dependencies): Add @momentum-ui/icons to react project

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -77,6 +77,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@momentum-ui/core": "^18.3.7",
+    "@momentum-ui/icons": "^7.0.0",
     "@momentum-ui/utils": "^6.0.3",
     "dom-helpers": "^3.4.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
Explicitly require @momentum-ui/icons as a dependency in react project.

## Description
There is an error when using [Yarn Plug'n'Play](https://yarnpkg.com/lang/en/docs/pnp/) to build a project using@momentum-ui/react. @momentum-ui/react is
trying to require @momentum-ui/icons without it being listed as a
dependency. The root cause stems from the Icon class, which attempts
to import from @momentum-ui/icons. I believe this hasn't error'd with the current module resolution system b/c @momentum-ui/icons is indirectly required as a dependency of core. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots:
![Screen Shot 2019-10-29 at 4 17 50 PM](https://user-images.githubusercontent.com/14286904/67810317-60dab700-fa68-11e9-966f-9e9060ccb6d6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
