### PR TITLE
fix(tooltip): enable custom delay for tooltip when allowHover is true

### DIFF
--- a/angular/src/lib/tooltip/tooltip.directive.ts
+++ b/angular/src/lib/tooltip/tooltip.directive.ts
@@ -70,13 +70,14 @@ export class TooltipDirective implements OnDestroy {
 
   ngOnDestroy() {
     this.delay = 0;
+    this.isOnTarget = false;
     this.close();
   }
 
   @HostListener('mouseenter')
   showtoolitp() {
     if ( this.tooltipTrigger === 'MouseEnter') {
-      this.isOnTarget = true;
+      this.isOnTarget = this.allowHover; // only checks on allowHover is true
       this.show();
     }
   }
@@ -199,10 +200,7 @@ export class TooltipDirective implements OnDestroy {
     positionStrategy: strategy as FlexibleConnectedPositionStrategy ,
     scrollStrategy: this._sso.close(),
   });
-  // if we want to keep the tooltip open to click on a link we need a bit of a delay
-  if ( this.allowHover ) {
-    this.delay = 900;
-  }
+
   if ( !this.tooltipRef ) {
     this.tooltipRef
       = this.overlayRef.attach(new ComponentPortal(TooltipContainerComponent));
@@ -221,7 +219,6 @@ export class TooltipDirective implements OnDestroy {
         this.eventSubs = new Subscription();
         this.eventSubs.add(this.tooltipRef.instance.mouseLeaveEvent.subscribe(() => {
           this.keepTooltipOpen = false;
-          this.delay = 500;
           this.close();
         }));
         this.eventSubs.add(this.tooltipRef.instance.mouseEnterEvent.subscribe(keepOpen => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Enable custom delay for tooltip when allowHover is true
- Fix behavior on destroy

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
