### PR TITLE
style(side-panel): match latest UI spec

### DIFF
--- a/core/scss/ng/breadcrumbs.scss
+++ b/core/scss/ng/breadcrumbs.scss
@@ -2,5 +2,6 @@
 @include exports('ng-breadcrumbs') {
   .md-breadcrumbs {
     @include vr-spacing(ph, 0);
+    @include vr-spacing(pb, 1.5);
   }
 }

--- a/core/scss/ng/settings/sidepanel.scss
+++ b/core/scss/ng/settings/sidepanel.scss
@@ -1,6 +1,6 @@
 $side-panel-width: rem-calc(533);
-$side-panel-padding: rem-calc(25);
-$side-panel-header-height: rem-calc(90);
+$side-panel-padding: rem-calc(16);
+$side-panel-header-height: rem-calc(77);
 $feature-line-height: rem-calc(36);
 $side-panel-large-width: calc(100vw - 100px);
 $side-panel-container-large-width: calc(100vw - 102px);

--- a/core/scss/ng/side-panel.scss
+++ b/core/scss/ng/side-panel.scss
@@ -12,6 +12,8 @@
 // @import  '~@momentum-ui/icons/scss/mixins';
 @import '~@momentum-ui/icons/scss/symphony/variable-mapping';
 
+$sidepanel-header-content-height: rem-calc(40);
+
 @include exports('ng-sidepanel') {
   .sidepanel-modal:focus {
     outline: none;
@@ -105,12 +107,14 @@
    */
     .side-panel-close {
       position: absolute;
-      top: 10px;
-      right: 10px;
+      top: rem-calc(16);
+      right: rem-calc(16);
 
       .panel-close {
+        line-height: 1;
+
         &:before {
-          font-size: rem-calc(25);
+          font-size: rem-calc(16);
         }
 
         &:focus {
@@ -125,29 +129,30 @@
     .side-panel-header {
       display: flex;
       height: $side-panel-header-height;
-      padding: 10px $side-panel-padding;
+      padding: $side-panel-padding $side-panel-padding rem-calc(20);
       border-bottom: 1px solid $md-gray-30;
     }
 
     .header-image {
-      min-width: 70px;
-      margin-right: 20px;
+      width: $sidepanel-header-content-height;
+      height: $sidepanel-header-content-height;
+      margin-right: rem-calc(16);
     }
 
     .user-img {
-      width: 70px;
-      height: 70px;
+      width: $sidepanel-header-content-height;
+      height: $sidepanel-header-content-height;
 
       .icon-user {
-        font-size: 60px;
-        line-height: 85px;
+        font-size: rem-calc(20);
+        line-height: 2;
       }
     }
 
     .header-info {
       display: flex;
       width: 100%;
-      height: 70px;
+      height: $sidepanel-header-content-height;
       min-width: 0;
       align-items: center;
 
@@ -164,10 +169,10 @@
 
     .header-title {
       display: flex;
-      padding-top: rem-calc(2);
+      // padding-top: rem-calc(2);
       margin-bottom: rem-calc(6);
       font-family: $brand-font-light;
-      font-size: rem-calc(26);
+      font-size: rem-calc(16);
       line-height: 1;
       color: $md-gray-70;
       align-items: center;
@@ -179,12 +184,12 @@
       > span {
         @include text-overflow;
 
-        max-width: 70%;
+        max-width: 80%;
       }
     }
 
     .edit-button {
-      font-size: rem-calc(20);
+      font-size: rem-calc(16);
       color: $md-gray-40;
 
       @include vr-spacing(ml, 0.25);
@@ -197,6 +202,7 @@
     .header-sub-info {
       position: relative;
       font-family: $brand-font-light;
+      font-size: rem-calc(12);
       line-height: 1;
       color: $md-gray-70;
 


### PR DESCRIPTION
Updating core CSS (without changing the HTML) to the sidepanels to match the latest UI spec I got from Kevin:

![Drawer as Side Panel 1 0 - Level 1_margins + padding](https://user-images.githubusercontent.com/211630/72262579-82831d80-3617-11ea-9dc8-e6215c0c017d.png)

This is how it looks in Control Hub, when paired with another similar PR for Control Hub (https://sqbu-github.cisco.com/WebExSquared/wx2-admin-web-client/pull/13577):

<img width="538" alt="Screenshot 2020-01-13 at 15 10 36" src="https://user-images.githubusercontent.com/211630/72262655-a5adcd00-3617-11ea-8ea8-5b206ab1b808.png">
