### PR TITLE
fix(modal): add type to close modal button

### DIFF
--- a/angular/src/lib/modal/modal-header.component.ts
+++ b/angular/src/lib/modal/modal-header.component.ts
@@ -22,6 +22,7 @@ import { ModalRef } from './modal-ref';
     (click)="close()"
     (keydown)="handleKeydown($event)"
     aria-label="close"
+    type="button"
   >
   </button>
   `,

--- a/angular/src/lib/modal/tests/__snapshots__/modal.component.spec.ts.snap
+++ b/angular/src/lib/modal/tests/__snapshots__/modal.component.spec.ts.snap
@@ -45,6 +45,7 @@ exports[`Modal Service modal should open when modalService is called 1`] = `
           <button
             aria-label="close"
             class="md-close md-modal__close"
+            type="button"
           />
         </md-modal-header>
         <md-modal-body


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `type=button` to the closing modal button.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/momentum-design/momentum-ui/issues/535

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Momentum Angular Playground. This change only affects one test snapshot which has been updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
