### PR TITLE
fix(modal): remove keydown event on close button

### DIFF
--- a/angular/src/lib/modal/modal-header.component.ts
+++ b/angular/src/lib/modal/modal-header.component.ts
@@ -20,7 +20,6 @@ import { ModalRef } from './modal-ref';
     *ngIf="showCloseButton"
     class="md-close md-modal__close"
     (click)="close()"
-    (keydown)="handleKeydown($event)"
     aria-label="close"
   >
   </button>

--- a/core/scss/components/modal/modal.scss
+++ b/core/scss/components/modal/modal.scss
@@ -43,10 +43,6 @@
           @include flex;
 
           border: none;
-
-          &:focus {
-            box-shadow: none;
-          }
         }
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Show the box shadow when the modal close button is focused.
2. Remove keydown event.

Note that, when pressing Enter or Space while the focus is on the button, the browser triggers a click event and the modal will get closed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/momentum-design/momentum-ui/issues/537

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
