### PR TITLE
feat(angularjs): allow 'mdTokenField' to work with UpgradeComponent

### DIFF
--- a/angularjs/src/lib/components/tokenfield/tokenfield.component.ts
+++ b/angularjs/src/lib/components/tokenfield/tokenfield.component.ts
@@ -9,7 +9,9 @@ export interface ITokenField extends ng.IScope {
 export class TokenField implements ng.IDirective {
   constructor(private $timeout: ng.ITimeoutService) {}
 
-  public preLink: ng.IDirectiveLinkFn = (scope: ITokenField, elem: any, attr: ng.IAttributes) => {
+  public link: ng.IDirectiveLinkFn = (scope: ITokenField, elem: any, attr: ng.IAttributes) => {
+    const tokenfieldElem = elem.find('> input');
+
     // Get delimiter from tokenoptions or default to comma
     let delimiterOpts = _.get(scope.tokenoptions, 'delimiter', [',']).join('');
     let delimiter = _.escapeRegExp(delimiterOpts);
@@ -35,13 +37,13 @@ export class TokenField implements ng.IDirective {
           e.preventDefault();
           // Split on our delimiters and create new tokens
           _.forEach(_.trim(data).split(delimiterRegEx), token => {
-            elem.tokenfield('createToken', _.trim(token));
+            tokenfieldElem.tokenfield('createToken', _.trim(token));
           });
         } catch (e) {
           // do nothing
         }
       };
-      elem
+      tokenfieldElem
         .tokenfield(scope.tokenoptions)
         .on('tokenfield:createtoken', e => {
           if (_.has(scope, 'tokenmethods.createtoken')) {
@@ -76,18 +78,16 @@ export class TokenField implements ng.IDirective {
         .data('bs.tokenfield')
         .$input.on('paste', pasteEvent);
     });
-  };
 
-  public postLink: ng.IDirectiveLinkFn = (scope: ITokenField, elem: ng.IAugmentedJQuery, attr: ng.IAttributes) => {
     if (scope.static) {
       this.$timeout(() => {
-        let tokenField = elem.parent();
-        tokenField.addClass('form-control-static').removeClass('form-control');
-        let tokenInput = tokenField.find('input').last();
+        let tokenFieldElemParent = tokenfieldElem.parent();
+        tokenFieldElemParent.addClass('form-control-static').removeClass('form-control');
+        let tokenInput = tokenFieldElemParent.find('input').last();
         tokenInput.attr('readonly', 'true');
 
         // Make the input editable when token is being edited
-        elem
+        tokenfieldElem
           .on('tokenfield:edittoken', () => {
             tokenInput.removeAttr('readonly');
           })
@@ -97,11 +97,6 @@ export class TokenField implements ng.IDirective {
       });
     }
   };
-
-  public compileFxn = (): any => ({
-    pre: this.preLink,
-    post: this.postLink,
-  });
 
   public restrict = 'AE';
   public scope = {
@@ -113,9 +108,7 @@ export class TokenField implements ng.IDirective {
     tokenpattern: '=',
     static: '=',
   };
-  public replace = true;
   public template = `<input type="{{tokenoptions.inputType}}" class="form-control token-input" id="{{tokenfieldid}}" ng-model="tokens" placeholder="{{tokenplaceholder}}" ng-pattern="{{tokenpattern}}"/>`;
-  public compile: ng.IDirectiveCompileFn = this.compileFxn;
 }
 
 tokenFieldFactory.$inject = ['$timeout'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- replace preLink/postLink with single link function
- remove `replace` and select correct element for tokenfield jquery

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
