### PR TITLE
fix(select): clear out filter value on overlay close and restore options, fix for onPush change detection, add export for table checkbox

### DIFF
--- a/angular/src/lib/data-table/index.ts
+++ b/angular/src/lib/data-table/index.ts
@@ -1,3 +1,4 @@
 export * from './data-table.module';
 export * from './data-table.component';
 export * from './data-table-scroll.component';
+export * from './data-table-checkbox.component';

--- a/angular/src/lib/select/select.component.ts
+++ b/angular/src/lib/select/select.component.ts
@@ -613,6 +613,7 @@ export class SelectComponent implements AfterContentChecked, AfterContentInit, C
       this.overlayOpen = false;
     }
     this.selectedOption = this.finalOption;
+    this.onFilter({target: ''});
   }
 
   onModelChange: Function = () => {};

--- a/angular/src/lib/select/select.component.ts
+++ b/angular/src/lib/select/select.component.ts
@@ -229,9 +229,6 @@ export class SelectComponent implements AfterContentChecked, AfterContentInit, C
   @Input() id = uniqueId('md-select-');
   /** @prop Optional prop to know if user is able to select multiple options | false */
   @Input() isMulti = false;
-  /** @prop Optional prop to to set the setTimeout duration for closing the panel | false */
-  @Input() closeDuration: number = 150;
-
 
   /** @prop emitter to fire the select option value change  */
   @Output() handleChange: EventEmitter<any> = new EventEmitter();
@@ -450,11 +447,10 @@ export class SelectComponent implements AfterContentChecked, AfterContentInit, C
         this.tableService.onSelectChange(option.value, this.tableRowIndex);
       }
     }
-    setTimeout(() => {
-      if (!this.isMulti) {
-        this.close();
-      }
-    }, this.closeDuration);
+
+    if (!this.isMulti) {
+      this.close();
+    }
   }
 
   private forceSelectItem(emit: boolean = false) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

PROVISION-5931


Filter value clears after close/detach restoring original select options to show

export data table checkbox component  

fix for ChangeDetectionStrategy.OnPush, the setTimeout was creating issues not closing the select overlay after single click when onPush is used, removed closeDuration prop fixing issue 

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
