### PR TITLE
fix(modal) : added cdkTrapFocusAutoCapture 

### DIFF
--- a/angular/src/lib/modal/modal-header.component.ts
+++ b/angular/src/lib/modal/modal-header.component.ts
@@ -22,6 +22,7 @@ import { ModalRef } from './modal-ref';
     (click)="close()"
     aria-label="close"
     type="button"
+    tabIndex="-1"
   >
   </button>
   `,

--- a/angular/src/lib/modal/modal.component.ts
+++ b/angular/src/lib/modal/modal.component.ts
@@ -28,7 +28,7 @@ export type SizeType =
       attr.aria-labelledby="{{ariaLabel}}"
       aria-modal="true"
     >
-      <div class="md-modal__content" cdkTrapFocus >
+      <div class="md-modal__content" cdkTrapFocusAutoCapture >
         <div class="md-modal__flex-container">
           <ng-content></ng-content>
         </div>

--- a/angular/src/lib/modal/tests/__snapshots__/modal.component.spec.ts.snap
+++ b/angular/src/lib/modal/tests/__snapshots__/modal.component.spec.ts.snap
@@ -16,15 +16,9 @@ exports[`Modal Service modal should open when modalService is called 1`] = `
     role="dialog"
   >
     <div
-      aria-hidden="true"
-      class="cdk-visually-hidden cdk-focus-trap-anchor"
-      tabindex="0"
-    />
-    <div
       _ngcontent-a-c0=""
-      cdktrapfocus=""
+      cdktrapfocusautocapture=""
       class="md-modal__content"
-      ng-reflect-enabled=""
     >
       <div
         _ngcontent-a-c0=""
@@ -45,6 +39,7 @@ exports[`Modal Service modal should open when modalService is called 1`] = `
           <button
             aria-label="close"
             class="md-close md-modal__close"
+            tabindex="-1"
             type="button"
           />
         </md-modal-header>
@@ -58,11 +53,6 @@ exports[`Modal Service modal should open when modalService is called 1`] = `
         />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      class="cdk-visually-hidden cdk-focus-trap-anchor"
-      tabindex="0"
-    />
   </div>
 </md-modal>
 `;


### PR DESCRIPTION
replaced cdkTrapFocusFix with cdkTrapFocusAutoCapture so that first focusable element will be focused instead of last when the modal is opened

Fix: Now description input is focused instead of code input when modal is opened
![Screen Shot 2020-03-12 at 3 16 59 PM](https://user-images.githubusercontent.com/15917537/76563116-c5753c00-6474-11ea-936a-19c4b7a122ad.png)



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
