### PR TITLE
fix(modal): Set the backdropClass for the angular modals

### DIFF
--- a/angular/src/lib/modal/modal.service.ts
+++ b/angular/src/lib/modal/modal.service.ts
@@ -38,6 +38,7 @@ constructor(private overlay: Overlay, private injector: Injector) {}
     const config = new OverlayConfig({
       hasBackdrop:  true || backdrop,
       positionStrategy: strategy,
+      backdropClass: 'md-modal__backdrop',
     });
     const overlayRef = this.overlay.create(config);
     const modalRef = new ModalRef(overlayRef, content, data, backdropClickExit);


### PR DESCRIPTION
## Description
The angular modal overlay config is missing the backdrop class. The consequence is that the overlay backdrop color is inconsistent between the angularjs and angular modals.

## Motivation and Context
Make the angularjs and angular modal backdrop color consistent.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)