### PR TITLE
fix(angular-selector): default to an empty array in makeSelectOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn-*
 
 # Ignore IDE files #
 ####################
+*.code-workspace
 build
 bundle.js
 bundle.js.map

--- a/angular/src/lib/select/select.component.ts
+++ b/angular/src/lib/select/select.component.ts
@@ -206,8 +206,8 @@ export class SelectComponent implements AfterContentChecked, AfterContentInit, C
     return this._options;
   }
 
-  set options(item: any[]) {
-    const options = this.optionLabel ? this.makeSelectOptions(item, this.optionLabel) : item;
+  set options(items: any[]) {
+    const options = this.optionLabel ? this.makeSelectOptions(items, this.optionLabel) : items;
     this._options = options;
     this.selectOptionsToDisplay = this._options;
     this.updateSelectedItem(this.value);
@@ -390,9 +390,8 @@ export class SelectComponent implements AfterContentChecked, AfterContentInit, C
   }
 
   makeSelectOptions(option: any[], label: string) {
-    let selectItems;
+    const selectItems = [];
     if (option && option.length) {
-      selectItems = [];
       for (const item of option) {
         selectItems.push({label: item[label], value: item, disabled: item['disabled']});
       }

--- a/angular/src/lib/select/tests/select.component.spec.ts
+++ b/angular/src/lib/select/tests/select.component.spec.ts
@@ -143,4 +143,20 @@ describe('SelectComponent', () => {
 
     expect(selectComponent.overlayOpen).toBe(true);
   }));
+
+    it('should open the overlay of options when select button is invoked even the options array is empty', fakeAsync(() => {
+    testComponent.people = [];
+    fixture.detectChanges();
+
+    selectNativeElement = fixture.nativeElement;
+    const button = selectNativeElement.querySelector('button');
+    expect(button).not.toBeNull();
+
+    // open overlay
+    button.click();
+    fixture.detectChanges();
+    flush();
+
+    expect(selectComponent.overlayOpen).toBe(true);
+  }));
 });


### PR DESCRIPTION
default to an empty array in makeSelectOptions if the input options are an empty array

Closes internal jiras

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
