### PR TITLE
feat(Lightbox): pass img class name to viewport

### DIFF
--- a/react/src/lib/Lightbox/index.js
+++ b/react/src/lib/Lightbox/index.js
@@ -127,7 +127,7 @@ class Lightbox extends React.Component {
   }
 
   render() {
-    const { pages, index, width, height, tooltips, downloading, info, name, applicationId } = this.props;
+    const { pages, index, width, height, tooltips, downloading, info, name, applicationId, imgClassName } = this.props;
     const { zoom, viewportDimensions } = this.state;
     const currentPage = pages[index];
     const showColumn = pages.length > 1;
@@ -250,7 +250,7 @@ class Lightbox extends React.Component {
           viewport = (
             <img
               alt=""
-              className="md-lightbox__viewport-image"
+              className={"md-lightbox__viewport-image" + `${(imgClassName && ` ${imgClassName}`) || ''}`}
               draggable="false"
               onClick={this.stopPropagation}
               onKeyPress={this.stopPropagation}
@@ -265,7 +265,7 @@ class Lightbox extends React.Component {
           viewport = (
             <img
               alt=""
-              className="md-lightbox__viewport-image"
+              className={"md-lightbox__viewport-image" + `${(imgClassName && ` ${imgClassName}`) || ''}`}
               draggable="false"
               onClick={this.stopPropagation}
               onKeyPress={this.stopPropagation}
@@ -500,6 +500,8 @@ Lightbox.propTypes = {
   downloading: PropTypes.bool,
   /** @prop Set Height value of Lightbox */
   height: PropTypes.number.isRequired,
+  /** @prop Classname appended to img viewport | '' */
+  imgClassName: PropTypes.string,
   /** @prop Initial index of start page | 0 */
   index: PropTypes.number,
   /** @prop Lightbox information Object | {} */
@@ -535,6 +537,7 @@ Lightbox.propTypes = {
 Lightbox.defaultProps = {
   decrypting: false,
   downloading: false,
+  imgClassName: '',
   index: 0,
   info: {},
   name: '',

--- a/react/src/lib/Lightbox/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/Lightbox/tests/__snapshots__/index.spec.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     decrypting={false}
     downloading={false}
     height={100}
+    imgClassName=""
     index={0}
     info={Object {}}
     name="test"

--- a/react/src/lib/Lightbox/tests/index.spec.js
+++ b/react/src/lib/Lightbox/tests/index.spec.js
@@ -62,6 +62,32 @@ describe('tests for <Lightbox />', () => {
     expect(spinner.length).toEqual(0);
   });
 
+  it('appends className to image', () => {
+    const className = "new-class-name";
+    const container = shallow(
+      <Lightbox
+        applicationId="app"
+        name="test"
+        height={100}
+        imgClassName={className}
+        width={100}
+        info={{
+          sharedBy:"Shared by abcd",
+          sharedOn: "At 4/17/2018, 10:02 AM",
+          size: "34.4 KB"
+        }}
+        pages={[{
+          decrypting: false,
+          image: "testImage",
+          thumb: "testImage"
+        }]}
+      />
+    );
+    const imageViewport = container.find('.md-lightbox__viewport-image');
+    expect(imageViewport.length).toEqual(1);
+    expect(imageViewport.prop('className')).toContain(className);
+  });
+
   it('should display file meta data and name', () => {
     const container = shallow(
       <Lightbox


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change allows user to pass in a class name to the img tag. For the web client's particular use case, some images that are attached need to be rotated and this classname allows to rotate the image. I believe this component was ported over from our old web-client-components repo, but don't think all the props were ported over in the first pass

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
see above description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
