### PR TITLE
 fix(Lightbox): update viewport dimensions onMount and display correct…

### DIFF
--- a/react/src/lib/Lightbox/examples/KitchenSink.js
+++ b/react/src/lib/Lightbox/examples/KitchenSink.js
@@ -1,15 +1,23 @@
 import React from 'react';
-import { Lightbox } from '@momentum-ui/react';
+import { Button, Lightbox } from '@momentum-ui/react';
 import reactIcon from '@momentum-ui/core/images/momentum/momentum.jpg';
 import ciscoWebex from '@momentum-ui/core/images/cisco-webex/lockup/cisco-webex-lockup-blue.png';
 
 export default class LightboxKitchenSink extends React.Component {
+  state = {
+    index: 0,
+    show: true
+  }
   render() {
     return (
       <React.Fragment>
-        <Lightbox
-          onClose={() => {}}
-          onChange={() => {}}
+        <Button onClick={() => {this.setState({show: true});}}>
+          Open
+        </Button>
+        {
+          this.state.show && <Lightbox
+          onClose={() => {this.setState({show: false});}}
+          onChange={idx => this.setState({ index: idx })}
           name="Screen Shot 2018-04-11 at 7.32.51 PM.png"
           applicationId="app"
           onDownload={() => {}}
@@ -19,7 +27,7 @@ export default class LightboxKitchenSink extends React.Component {
             sharedOn: 'At 4/17/2018, 10:02 AM',
             size: '34.4 KB',
           }}
-          index={0}
+          index={this.state.index}
           height={250}
           width={250}
           pages={[
@@ -35,6 +43,7 @@ export default class LightboxKitchenSink extends React.Component {
             },
           ]}
         />
+      }
       </React.Fragment>
     );
   }

--- a/react/src/lib/Lightbox/tests/__snapshots__/index.spec.js.snap
+++ b/react/src/lib/Lightbox/tests/__snapshots__/index.spec.js.snap
@@ -11,6 +11,7 @@ ShallowWrapper {
     imgClassName=""
     index={0}
     info={Object {}}
+    isImageRotated={false}
     name="test"
     onChange={null}
     onClose={null}


### PR DESCRIPTION
… % size of image

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes issue where image does not take up entire viewport on mount. The default width/height viewport dimensions were 600px/600px. This PR also fixes the size % where it always defaults to 100%. Now it will actually calculate the % of current size vs the full size

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in Playground with a large image as well as in the web client locally

## Screenshots:
**Before** (If applicable):
![Screen Shot 2020-04-13 at 12 03 52 PM](https://user-images.githubusercontent.com/819823/79151249-f9e35d00-7d7e-11ea-87f1-6c58f917c49b.png)


**After**:
![Screen Shot 2020-04-13 at 12 01 29 PM](https://user-images.githubusercontent.com/819823/79151270-ff40a780-7d7e-11ea-8da1-44d47649b299.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
