### PR TITLE
perf(checkbox): nest styles to work without input.scss

### DIFF
--- a/core/scss/components/checkbox/checkbox.scss
+++ b/core/scss/components/checkbox/checkbox.scss
@@ -104,10 +104,8 @@
       padding-top: 6px;
     }
 
-    .#{$prefix}-input__help-text {
-      @include input__help-text();
-      @include vr-spacing(pl, 2);
-    }
+    @include input__help-text-spacing
+
   }
   // Dark
   .#{$dark-class} {

--- a/core/scss/components/checkbox/module.scss
+++ b/core/scss/components/checkbox/module.scss
@@ -30,3 +30,40 @@
 // Component Specific
 @import 'mixins';
 @import 'checkbox';
+
+
+.#{$input__class}-container {
+    @include flex($fw: wrap, $jc: normal, $ac: normal, $ai: normal);
+    box-sizing: border-box;
+    line-height: $input__line-height;
+    margin-bottom: rem-calc(16);
+    position: relative;
+  
+    &.column,
+    &.columns {
+      padding: 0;
+    }
+  
+    &.#{$prefix}-disabled {
+      .#{$input__class}__label,
+      .#{$input__class}__secondary-label {
+        cursor: not-allowed;
+      }
+    }
+  
+    &.#{$input__class} {
+      &--nested {
+        &-1 {
+          padding-left: 2rem;
+        }
+  
+        &-2 {
+          padding-left: 4rem;
+        }
+  
+        &-3 {
+          padding-left: 6rem;
+        }
+      }
+    }
+  }

--- a/core/scss/components/checkbox/module.scss
+++ b/core/scss/components/checkbox/module.scss
@@ -23,7 +23,8 @@
 @import '../../tools/mixins/focus';
 @import '../../tools/mixins/spacing';
 @import '../../typography/mixins';
-@import '../../components/input/mixins';
+@import '../input/mixins';
+@import '../help-text/mixins';
 
 @include brand-font-face-regular;
 
@@ -31,39 +32,4 @@
 @import 'mixins';
 @import 'checkbox';
 
-
-.#{$input__class}-container {
-    @include flex($fw: wrap, $jc: normal, $ac: normal, $ai: normal);
-    box-sizing: border-box;
-    line-height: $input__line-height;
-    margin-bottom: rem-calc(16);
-    position: relative;
-  
-    &.column,
-    &.columns {
-      padding: 0;
-    }
-  
-    &.#{$prefix}-disabled {
-      .#{$input__class}__label,
-      .#{$input__class}__secondary-label {
-        cursor: not-allowed;
-      }
-    }
-  
-    &.#{$input__class} {
-      &--nested {
-        &-1 {
-          padding-left: 2rem;
-        }
-  
-        &-2 {
-          padding-left: 4rem;
-        }
-  
-        &-3 {
-          padding-left: 6rem;
-        }
-      }
-    }
-  }
+@include container-nesting;

--- a/core/scss/components/help-text/mixins.scss
+++ b/core/scss/components/help-text/mixins.scss
@@ -1,0 +1,6 @@
+@mixin input__help-text-spacing {
+  .#{$prefix}-input__help-text {
+    @include input__help-text();
+    @include vr-spacing(pl, 2);
+  }
+}

--- a/core/scss/components/help-text/module.scss
+++ b/core/scss/components/help-text/module.scss
@@ -8,43 +8,10 @@
 @import '../input/settings';
 
 @import '../../tools/mixins/spacing';
+@import '../input/mixins';
+@import './mixins';
 
-@mixin input__help-text(
-  $color: $input__font-color--help,
-  $color-dark: $input__font-color--help--dark,
-  $color-contrast: $input__font-color--help--contrast,
-  $color-dark-contrast: $input__font-color--help--dark--contrast
-) {
-  color: $input__font-color--help;
-  font-family: $brand-font-regular;
-  font-size: rem-calc(14);
-  line-height: rem-calc(22);
-  padding-left: rem-calc(16);
-
-  .#{$contrast-class} & {
-    color: $input__font-color--help--contrast;
-  }
-
-  .#{$dark-class} &,
-  .#{$input__class}-container--dark & {
-    color: $input__font-color--help--dark;
-
-    .#{$contrast-class} & {
-      color: $input__font-color--help--dark--contrast;
-    }
-  }
-
-  @include vr-spacing(mb, 0.25);
-
-  span {
-    font-size: inherit;
-  }
-}
-
-.#{$prefix}-input__help-text {
-  @include input__help-text();
-  @include vr-spacing(pl, 2);
-}
+@include input__help-text-spacing
 
 .#{$input__class} {
   &__help-text {

--- a/core/scss/components/help-text/module.scss
+++ b/core/scss/components/help-text/module.scss
@@ -1,0 +1,59 @@
+@import '../../tools/functions/core';
+
+@import '~@momentum-ui/icons/scss/variables';
+@import '../../colors/settings';
+@import '../../settings/core';
+@import '../../settings/media';
+@import '../../typography/settings';
+@import '../input/settings';
+
+@import '../../tools/mixins/spacing';
+
+@mixin input__help-text(
+  $color: $input__font-color--help,
+  $color-dark: $input__font-color--help--dark,
+  $color-contrast: $input__font-color--help--contrast,
+  $color-dark-contrast: $input__font-color--help--dark--contrast
+) {
+  color: $input__font-color--help;
+  font-family: $brand-font-regular;
+  font-size: rem-calc(14);
+  line-height: rem-calc(22);
+  padding-left: rem-calc(16);
+
+  .#{$contrast-class} & {
+    color: $input__font-color--help--contrast;
+  }
+
+  .#{$dark-class} &,
+  .#{$input__class}-container--dark & {
+    color: $input__font-color--help--dark;
+
+    .#{$contrast-class} & {
+      color: $input__font-color--help--dark--contrast;
+    }
+  }
+
+  @include vr-spacing(mb, 0.25);
+
+  span {
+    font-size: inherit;
+  }
+}
+
+.#{$prefix}-input__help-text {
+  @include input__help-text();
+  @include vr-spacing(pl, 2);
+}
+
+.#{$input__class} {
+  &__help-text {
+    display: inline-flex;
+    padding-left: rem-calc(16);
+    padding-top: rem-calc(8);
+    width: 100%;
+    font-family: $brand-font-regular;
+    font-size: $input__message__font-size;
+    line-height: $input__message__line-height;
+  }
+}

--- a/core/scss/components/input/input.scss
+++ b/core/scss/components/input/input.scss
@@ -58,42 +58,8 @@
     }
   }
 
-  .#{$input__class}-container {
-    @include flex($fw: wrap, $jc: normal, $ac: normal, $ai: normal);
-    box-sizing: border-box;
-    margin-bottom: rem-calc(16);
-    position: relative;
-    line-height: $input__line-height;
-
-    &.column,
-    &.columns {
-      padding: 0;
-    }
-
-    &.#{$prefix}-disabled {
-      .#{$input__class}__label,
-      .#{$input__class}__secondary-label {
-        cursor: not-allowed;
-      }
-    }
-
-    &.#{$input__class} {
-      &--nested {
-        &-1 {
-          padding-left: 2rem;
-        }
-
-        &-2 {
-          padding-left: 4rem;
-        }
-
-        &-3 {
-          padding-left: 6rem;
-        }
-      }
-    }
-  }
-
+  @include container-nesting;
+  
   .#{$input__class} {
     border: $input__border-width solid;
     border-radius: $input__border-radius;

--- a/core/scss/components/input/mixins.scss
+++ b/core/scss/components/input/mixins.scss
@@ -45,7 +45,6 @@
   $background-color-hover: null,
   $border-color: null
 ) {
-
   .#{$input__class}:not(.md-select__filter--input) {
     color: $color;
     background-color: $background-color;
@@ -96,7 +95,7 @@
   &.#{$prefix}-disabled {
     .#{$input__class} {
       &__before {
-        @include input-icon($color: $color-disabled)
+        @include input-icon($color: $color-disabled);
       }
     }
   }
@@ -104,14 +103,11 @@
   .#{$input__class} {
     &__after,
     &__before {
-      @include input-icon($color: $color)
+      @include input-icon($color: $color);
     }
 
     &__icon-clear {
-      @include input-clear-color(
-        $color-clear,
-        $color-clear-hover
-      );
+      @include input-clear-color($color-clear, $color-clear-hover);
     }
   }
 
@@ -129,10 +125,7 @@
   }
 }
 
-
-@mixin input-icon(
-  $color: null
-) {
+@mixin input-icon($color: null) {
   @if $color {
     color: $color;
     fill: $color;
@@ -146,7 +139,7 @@
 @mixin input-clear-color(
   $color: $input__clear-icon__color,
   $color-hover: $input__clear-icon__color--hover
-  ) {
+) {
   background-color: transparent;
   color: $color;
   fill: $color;
@@ -156,5 +149,43 @@
     background-color: transparent;
     color: $color-hover;
     fill: $color-hover;
+  }
+}
+
+@mixin container-nesting {
+  .#{$input__class}-container {
+    @include flex($fw: wrap, $jc: normal, $ac: normal, $ai: normal);
+    box-sizing: border-box;
+    margin-bottom: rem-calc(16);
+    position: relative;
+    line-height: $input__line-height;
+
+    &.column,
+    &.columns {
+      padding: 0;
+    }
+
+    &.#{$prefix}-disabled {
+      .#{$input__class}__label,
+      .#{$input__class}__secondary-label {
+        cursor: not-allowed;
+      }
+    }
+
+    &.#{$input__class} {
+      &--nested {
+        &-1 {
+          padding-left: 2rem;
+        }
+
+        &-2 {
+          padding-left: 4rem;
+        }
+
+        &-3 {
+          padding-left: 6rem;
+        }
+      }
+    }
   }
 }

--- a/core/scss/components/radio/module.scss
+++ b/core/scss/components/radio/module.scss
@@ -14,6 +14,7 @@
 @import '../../tools/mixins/focus';
 @import '../../tools/mixins/spacing';
 @import '../input/mixins';
+@import '../help-text/mixins';
 
 // Component Specific
 @import 'settings';

--- a/core/scss/components/radio/radio.scss
+++ b/core/scss/components/radio/radio.scss
@@ -84,11 +84,9 @@
       display: flex;
       flex-direction: column;
     }
-
-    .#{$prefix}-input__help-text {
-      @include input__help-text();
-      @include vr-spacing(pl, 2);
-    }
+    
+    @include input__help-text-spacing
+  
   }
 
   .#{$dark-class} {


### PR DESCRIPTION
Particularly within Web Components, having the nested style defined only within the Input component's module.scss leads to unnecessary and bloated imports of extra styles.

Similarly, styles for help-text lie within other component's styles, and can be more isolated for Web Component usage, so I've added a module.scss with plain help-text styles.

This fix enables the Checkbox to include the specific style declaration to have nested styling work.

## Description
Adding the nested style definitions to the Checkbox component's module.scss

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Visual testing within sandbox application.

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: Performance improvement for Web Component usage

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
