### PR TITLE
Change Browser Global Element to React Element to make momentum SSR-compatible again

### DIFF
--- a/react/src/lib/EventOverlay/index.js
+++ b/react/src/lib/EventOverlay/index.js
@@ -1034,8 +1034,8 @@ EventOverlay.propTypes = {
   maxHeight: PropTypes.number,
   /** @prop Sets the max width of the EventOverlay | null */
   maxWidth: PropTypes.number,
-  /** @prop Node/element where overlay should be appended using ReactDOM portal | null */
-  portalNode: PropTypes.oneOfType([PropTypes.node, PropTypes.instanceOf(Element)]),
+  /** @prop Node/ReactElement where overlay should be appended using ReactDOM portal | null */
+  portalNode: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
   /** @prop Set the id of the scrollParent | null */
   scrollParentID: PropTypes.string,
   /** @prop Determines if focus should be locked to overlay | false */


### PR DESCRIPTION
SSR applications can not use the latest version of momentum anymore. and the error is caused by [this line](https://github.com/momentum-design/momentum-ui/blob/master/react/src/lib/EventOverlay/index.js#L1038). I figured to use React Element instead of a Browser global.

## Description
change Browser defined Element to React Element.

## Related Issue
momentum components are not SSR-compatible anymore.

## Motivation and Context
to make momentum SSR compatible agian.

## How Has This Been Tested?
yes

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
