### PR TITLE
fix: don't show popover content if it's null

### DIFF
--- a/react/src/lib/ListItemMeeting/index.js
+++ b/react/src/lib/ListItemMeeting/index.js
@@ -162,7 +162,7 @@ class ListItemMeeting extends React.PureComponent {
       <ListItemSection key='child-2' position='right'>
         {childrenRight}
       </ListItemSection>,
-      isOpen && (
+      isOpen && !!popoverContent && (
         <EventOverlay
           key='child-3'
           direction='right-center'

--- a/react/src/lib/ListItemMeeting/tests/index.spec.js
+++ b/react/src/lib/ListItemMeeting/tests/index.spec.js
@@ -152,7 +152,17 @@ describe('tests for <ListItemMeeting />', () => {
     );
 
     container.find('.md-list-item').simulate('click');
+    expect(container.find('.md-event-overlay').length).toEqual(1);
     expect(container.find('.test').length).toEqual(1);
+  });
+
+  it('should not render popoverContent if there is no popoverContent!', () => {
+    const container = mount(
+      <ListItemMeeting {...props} />
+    );
+
+    container.find('.md-list-item').simulate('click');
+    expect(container.find('.md-event-overlay').length).toEqual(0);
   });
 
   describe('tests for time/isALlDay prop', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
MeetingListItem shows an empty popover (event overlay) if you don't pass it any content. Some people may not want a popover. Let's support that!

## How Has This Been Tested?
Wrote a new Jest test

## Screenshots:
**Before** (If applicable):
![Screen Shot 2020-07-17 at 4 55 52 PM](https://user-images.githubusercontent.com/2391772/87836781-75f1b300-c84e-11ea-8db9-275962334aac.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
