### PR TITLE
manro/more tab bound to right + no-grow

### DIFF
--- a/web-components/src/components/tabs/Tabs.test.ts
+++ b/web-components/src/components/tabs/Tabs.test.ts
@@ -115,7 +115,7 @@ describe("Tabs", () => {
     }
 
     await elementUpdated(tabs);
-    expect(consoleSpy).toHaveBeenCalledWith("The tabs or panels count should't equal zero.");
+    expect(consoleSpy).toHaveBeenCalledWith("The tabs or panels count should't be equal zero.");
 
     consoleSpy.mockRestore();
   });

--- a/web-components/src/components/tabs/Tabs.ts
+++ b/web-components/src/components/tabs/Tabs.ts
@@ -54,7 +54,7 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
   @queryAll(".md-menu-overlay__more_list md-tab") tabsCopyHiddenListElements?: NodeListOf<Tab>;
 
   @internalProperty() private isMoreTabMenuVisible = false;
-  @internalProperty() private isMoreTabMenuGrow = false;
+  @internalProperty() private isMoreTabMenuMeasured = false;
   @internalProperty() private isMoreTabMenuOpen = false;
   @internalProperty() private isMoreTabMenuSelected = false;
   @internalProperty() private moreTabMenuOffsetWidth = 0;
@@ -101,7 +101,8 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
   }
 
   private async manageOverflow() {
-    if (this.tabsListElement && this.tabs.length > 1) {
+    const tabsCount = this.tabs.length;
+    if (this.tabsListElement && tabsCount > 1) {
       const tabsListViewportOffsetWidth = this.tabsListElement.offsetWidth;
 
       // Awaiting tabs updates
@@ -127,6 +128,7 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
       }, 0);
 
       if (tabsTotalOffsetWidth) {
+        // more
         await this.setupMoreTab();
 
         let isTabsFitInViewport = true;
@@ -144,7 +146,7 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
 
           const isTabInViewportHidden = isTabsFitInViewport
             ? false
-            : tabsOffsetWidthSum + (idx < this.tabs.length - 1 ? this.moreTabMenuOffsetWidth : 0) >
+            : tabsOffsetWidthSum + (idx < tabsCount - 1 ? this.moreTabMenuOffsetWidth : 0) >
               tabsListViewportOffsetWidth;
 
           newTabsViewportList.push({
@@ -200,7 +202,7 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
     const { tabs, panels } = this;
 
     if (tabs.length === 0 || panels.length === 0) {
-      console.warn(`The tabs or panels count should't equal zero.`);
+      console.warn(`The tabs or panels count should't be equal zero.`);
       return;
     }
 
@@ -474,11 +476,11 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
   }
 
   private async setupMoreTab() {
-    if (this.moreTabMenuElement && !this.isMoreTabMenuGrow) {
+    if (this.moreTabMenuElement && !this.isMoreTabMenuMeasured) {
       await this.moreTabMenuElement.updateComplete;
       if (this.moreTabMenuElement.offsetWidth) {
         this.moreTabMenuOffsetWidth = this.moreTabMenuElement.offsetWidth;
-        this.isMoreTabMenuGrow = true;
+        this.isMoreTabMenuMeasured = true;
       }
     }
   }
@@ -524,8 +526,7 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
         <md-menu-overlay
           custom-width="${MORE_MENU_WIDTH}"
           class="md-menu-overlay__more ${classMap({
-            "md-menu-overlay__more--grow": this.isMoreTabMenuGrow,
-            "md-menu-overlay__more--hidden": this.isMoreTabMenuGrow && !this.isMoreTabMenuVisible
+            "md-menu-overlay__more--hidden": this.isMoreTabMenuMeasured && !this.isMoreTabMenuVisible
           })}"
           @menu-overlay-open="${() => {
             this.isMoreTabMenuOpen = true;

--- a/web-components/src/components/tabs/scss/tabs.scss
+++ b/web-components/src/components/tabs/scss/tabs.scss
@@ -25,14 +25,10 @@
 
   .md-menu-overlay__more {
     height: 100%;
-    max-width: 10rem;
-
-    &.md-menu-overlay__more--grow {
-      flex-grow: 1;
-    }
+    width: auto;
+    margin-left: auto;
 
     &.md-menu-overlay__more--hidden {
-      flex-grow: initial;
       pointer-events: none;
       visibility: hidden;
       width: 0 !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In case when tabs items overfits their container - "more" dropdown menu bounds to right border and fold width

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
