### PR TITLE
fix(mixin): fix issue with tabbing in sequentially and click focusable new elements

### DIFF
--- a/web-components/src/[sandbox]/examples/modal.ts
+++ b/web-components/src/[sandbox]/examples/modal.ts
@@ -2,6 +2,7 @@ import "@/components/button/Button";
 import "@/components/modal/Modal";
 import "@/components/tabs/Tab";
 import "@/components/tabs/TabPanel";
+import {  comboBoxOptions } from "@/[sandbox]/sandbox.mock";
 import "@/components/tabs/Tabs";
 import { customElement, html, LitElement, property } from "lit-element";
 
@@ -10,6 +11,7 @@ export class ModalTemplateSandbox extends LitElement {
   @property({ type: Boolean }) isModalOpen = false;
   @property({ type: Boolean }) isComplexModalOpen = false;
   @property({ type: Boolean }) isDialogOpen = false;
+  @property({ type: Boolean }) isComplexTabsModal = false;
 
   private openModal() {
     this.isModalOpen = true;
@@ -35,11 +37,20 @@ export class ModalTemplateSandbox extends LitElement {
     this.isDialogOpen = false;
   }
 
+  private openComplexTabsModal() {
+    this.isComplexTabsModal = true;
+  }
+
+  private closeComplexTabsModal() {
+    this.isComplexTabsModal = false;
+  }
+
   render() {
     return html`
       <md-button @click=${this.openModal}>Open Modal</md-button>
       <md-button @click=${this.openDialog}>Open Dialog</md-button>
       <md-button @click=${this.openComplexModal}>Open Complex Modal</md-button>
+      <md-button @click=${this.openComplexTabsModal}>Open Complex Tabs Modal</md-button>
       <md-modal
         htmlId="modal-1"
         ?show=${this.isModalOpen}
@@ -142,6 +153,50 @@ export class ModalTemplateSandbox extends LitElement {
             <button type="button">Cisco WxM</button>
           </md-tab-panel>
         </md-tabs>
+      </md-modal>
+
+      <md-modal
+        ?show=${this.isComplexTabsModal}
+        size="small"
+        hideFooter
+        hideHeader
+        @close-modal="${this.closeComplexTabsModal}"
+      >
+        <div slot="header">
+          <h3 class="sl-form-label">Station Login</h3>
+        </div>
+        <md-tabs justified>
+          <md-tab slot="tab" label="Dial Number">
+            <span>Dial Number</span>
+          </md-tab>
+          <md-tab-panel slot="panel">
+            <div class="phone-fromat">
+              <md-radiogroup group-label="phone-fromat" alignment="horizontal" checked="0">
+                <md-radio slot="radio" value="US" aria-label="US Format">US Format</md-radio>
+                <md-radio slot="radio" value="Other" ariaLabel="Other">Other</md-radio>
+              </md-radiogroup>
+            </div>
+
+            <md-input type="tel" id="dn" placeholder="Dial Number" shape="pill" autofocus></md-input>
+          </md-tab-panel>
+          <md-tab slot="tab" label="Extension">
+            <span>Extension</span>
+          </md-tab>
+          <md-tab-panel slot="panel">
+            <div class="extension-format">
+              <md-input aria-label="Team X" type="tel" id="ext" placeholder="Team X" shape="pill"></md-input>
+            </div>
+            <md-combobox placeholder="Choose Team" .options=${comboBoxOptions}></md-combobox>
+          </md-tab-panel>
+        </md-tabs>
+        <div class="sl-footer" slot="footer">
+          <md-button class="footer-btn" aria-label="Cancel" @click="${this.closeComplexTabsModal}">
+            Cancel
+          </md-button>
+          <md-button class="footer-btn" variant="primary" aria-label="Submit" @click="${this.closeComplexTabsModal}">
+            Submit
+          </md-button>
+        </div>
       </md-modal>
     `;
   }

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -121,7 +121,9 @@ export class ComboBox extends FocusMixin(LitElement) {
 
   protected handleFocusIn(event: Event) {
     if (!this.disabled) {
-      this.input!.focus();
+      requestAnimationFrame(() => {
+        this.input!.focus();
+      });
       super.handleFocusIn && super.handleFocusIn(event);
     }
     this.dispatchEvent(

--- a/web-components/src/components/menu-overlay/MenuOverlay.test.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.test.ts
@@ -180,10 +180,10 @@ describe("MenuOverlay", () => {
 
   test("should execute handleOutsideClick", async () => {
     const element = await fixtureFactory(true, false, "bottom", "", "", "large");
-    const mockhandleOutsideClick = jest.spyOn(element, "handleOutsideClick");
+    const mockhandleOutsideClick = jest.spyOn(element, "handleOutsideOverlayClick");
     const event = new MouseEvent("click");
 
-    element.handleOutsideClick(event);
+    element.handleOutsideOverlayClick(event);
     await elementUpdated(element);
 
     expect(mockhandleOutsideClick).toHaveBeenCalled();
@@ -196,7 +196,7 @@ describe("MenuOverlay", () => {
     const event = new MouseEvent("click");
     await nextFrame();
 
-    element.handleOutsideClick(event);
+    element.handleOutsideOverlayClick(event);
     await elementUpdated(element);
     expect(element.arrow).not.toBeNull();
   });

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -112,14 +112,14 @@ export class MenuOverlay extends FocusTrapMixin(LitElement) {
 
   connectedCallback() {
     super.connectedCallback();
-    document.addEventListener("click", this.handleOutsideClick);
-    document.addEventListener("keydown", this.handleOutsideKeydown);
+    document.addEventListener("click", this.handleOutsideOverlayClick);
+    document.addEventListener("keydown", this.handleOutsideOverlayKeydown);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    document.removeEventListener("click", this.handleOutsideClick);
-    document.removeEventListener("keydown", this.handleOutsideKeydown);
+    document.removeEventListener("click", this.handleOutsideOverlayClick);
+    document.removeEventListener("keydown", this.handleOutsideOverlayKeydown);
 
     if (this.triggerElement) {
       this.triggerElement.removeEventListener("click", this.handleTriggerClick);
@@ -269,7 +269,7 @@ export class MenuOverlay extends FocusTrapMixin(LitElement) {
     }
   }
 
-  handleOutsideKeydown = async (event: KeyboardEvent) => {
+  handleOutsideOverlayKeydown = async (event: KeyboardEvent) => {
     let insideMenuKeyDown = false;
     const path = event.composedPath();
     if (path.length) {
@@ -332,7 +332,7 @@ export class MenuOverlay extends FocusTrapMixin(LitElement) {
     }
   }
 
-  handleOutsideClick = (event: MouseEvent) => {
+  handleOutsideOverlayClick = (event: MouseEvent) => {
     let insideMenuClick = false;
     const path = event.composedPath();
     if (path.length) {

--- a/web-components/src/components/tabs/Tab.test.ts
+++ b/web-components/src/components/tabs/Tab.test.ts
@@ -2,7 +2,7 @@ import { Key } from "@/constants";
 import { uuid } from "@/utils/helpers";
 import { defineCE, elementUpdated, fixture, fixtureCleanup, fixtureSync, oneEvent } from "@open-wc/testing-helpers";
 import { html, PropertyValues } from "lit-element";
-import "./Tab";
+import "@/components/tabs/Tab";
 import { Tab } from "./Tab";
 
 describe("Tab", () => {
@@ -66,5 +66,23 @@ describe("Tab", () => {
     expect(keydown).toBeDefined();
     expect(keydown.id).toBe(id);
     expect(keydown.key).toBe(Key.Enter);
+  });
+
+  test("should dispatch event when selected", async() => {
+    const el = await fixture<Tab>(`<md-tab></md-tab>`);
+    const spySelected = jest.spyOn(el, "notifySelectedTab" as never);
+
+    el.selected = true;
+    await elementUpdated(el);
+
+    expect(spySelected).toHaveBeenCalled();
+    spySelected.mockRestore();
+  });
+
+  test("should set label property if it defined", async() => {
+    const el = await fixture<Tab>(`<md-tab label="Tab Label"></md-tab>`);
+
+    expect(el.hasAttribute("aria-label")).toBeTruthy();
+    expect(el.getAttribute("aria-label")).toEqual("Tab Label");
   });
 });

--- a/web-components/src/components/tabs/Tab.ts
+++ b/web-components/src/components/tabs/Tab.ts
@@ -46,6 +46,11 @@ export class Tab extends FocusMixin(LitElement) {
   set selected(value: boolean) {
     const oldValue = this._selected;
     this._selected = value;
+
+    if (value) {
+      this.notifySelectedTab();
+    }
+
     this.setAttribute("aria-selected", `${value}`);
     this.requestUpdate("selected", oldValue);
   }
@@ -85,6 +90,15 @@ export class Tab extends FocusMixin(LitElement) {
         })
       );
     }
+  }
+
+  private notifySelectedTab() {
+    this.dispatchEvent(
+      new CustomEvent("focus-visible", {
+        composed: true,
+        bubbles: true,
+      })
+    );
   }
 
   protected update(changedProperties: PropertyValues) {

--- a/web-components/src/components/tabs/tokens/md-tabs-tokens.js
+++ b/web-components/src/components/tabs/tokens/md-tabs-tokens.js
@@ -27,12 +27,8 @@ const tabs = {
       dark: colors.gray[90].name
     },
     "focus-border": {
-      light: "transparent",
-      dark: "transparent"
-    },
-    "focus-shadow": {
-      light: "0 0 4px 2px $md-blue-50",
-      dark: "0 0 4px 2px $md-blue-50"
+      light: colors.blue[60].name,
+      dark: colors.blue[40].name
     },
     "hover-border": {
       light: colors.gray[20].name,

--- a/web-components/src/mixins/FocusMixin.test.ts
+++ b/web-components/src/mixins/FocusMixin.test.ts
@@ -1,6 +1,6 @@
 import { defineCE, fixture, fixtureCleanup, fixtureSync, nextFrame, oneEvent } from "@open-wc/testing-helpers";
 import { customElement, html, LitElement, property, PropertyValues } from "lit-element";
-import { AnyConstructor, FocusMixin } from "./FocusMixin";
+import { AnyConstructor, FocusClass, FocusMixin } from "./FocusMixin";
 
 describe("Focus Mixin", () => {
   afterEach(fixtureCleanup);
@@ -16,7 +16,6 @@ describe("Focus Mixin", () => {
       `;
     }
   }
-
   test("should applying to component", async () => {
     const tag = defineCE(class extends FocusMixin(FocusMixin(CustomElement)) {});
     const el = await fixture<CustomElement>(`<${tag}></${tag}>`);
@@ -96,5 +95,26 @@ describe("Focus Mixin", () => {
 
     expect(element["getDeepActiveElement"]!()).toEqual(input);
     expect(element["isElementFocused"]!(input!)).toBeFalsy();
+  });
+
+  test("should dispatch event in focus/blur case", async () => {
+    const tag = defineCE(class extends FocusMixin(CustomElement) {});
+    const el = await fixture<CustomElement>(`<${tag}></${tag}>`);
+
+    const focusEvent = new Event("focus");
+    setTimeout(() => (el as FocusClass)["handleFocusIn"]!(focusEvent));
+
+    const { detail: focusDetail } = await oneEvent(el, "focus-visible");
+
+    expect(focusDetail).toBeDefined();
+    expect(focusDetail.sourceEvent).toEqual(focusEvent);
+
+    const blurEvent = new Event("blur");
+    setTimeout(() => (el as FocusClass)["handleFocusOut"]!(blurEvent));
+
+    const { detail: blurDetail } = await oneEvent(el, "focus-not-visible");
+
+    expect(blurDetail).toBeDefined();
+    expect(blurDetail.sourceEvent).toEqual(blurEvent);
   });
 });

--- a/web-components/src/mixins/FocusMixin.ts
+++ b/web-components/src/mixins/FocusMixin.ts
@@ -34,6 +34,7 @@ import { DedupeMixin, wasApplied } from "./DedupeMixin";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyConstructor<A = LitElement> = new (...input: any[]) => A;
+export type FocusEventDetail = { sourceEvent: Event };
 
 export abstract class FocusClass extends LitElement {
   protected setFocus?(force: boolean): void;
@@ -60,12 +61,16 @@ export const FocusMixin = <T extends AnyConstructor<FocusClass>>(base: T): T & A
       if (super.handleFocusIn) {
         super.handleFocusIn(event);
       }
+
       this.setFocus(true);
 
       this.dispatchEvent(
-        new CustomEvent("focus-visible", {
+        new CustomEvent<FocusEventDetail>("focus-visible", {
           composed: true,
-          bubbles: true
+          bubbles: true,
+          detail: {
+            sourceEvent: event
+          }
         })
       );
     }
@@ -77,9 +82,12 @@ export const FocusMixin = <T extends AnyConstructor<FocusClass>>(base: T): T & A
       this.setFocus(false);
 
       this.dispatchEvent(
-        new CustomEvent("focus-not-visible", {
+        new CustomEvent<FocusEventDetail>("focus-not-visible", {
           composed: true,
-          bubbles: true
+          bubbles: true,
+          detail: {
+            sourceEvent: event
+          }
         })
       );
     }

--- a/web-components/src/mixins/FocusTrapMixin.test.ts
+++ b/web-components/src/mixins/FocusTrapMixin.test.ts
@@ -343,4 +343,67 @@ describe("FocusTrap Mixin", () => {
 
     expect(focusTrap!["getDeepActiveElement"]!()).toEqual(input);
   });
+
+  test("should change focus trap index on click", async() => {
+    const focusTrap = el.shadowRoot!.querySelector<FocusTrap>("focus-trap");
+
+    focusTrap!["activateFocusTrap"]!();
+    focusTrap!["setFocusableElements"]!();
+
+    await elementUpdated(focusTrap!);
+
+    const button = focusTrap!.querySelector<HTMLButtonElement>("div button");
+
+    await elementUpdated(focusTrap!);
+    button!.click();
+
+    await nextFrame();
+    expect(focusTrap!.focusTrapIndex).toEqual(4);
+    expect(focusTrap!["getDeepActiveElement"]!()).toEqual(button);
+  });
+
+  test("should change focus trap index if focus-visible event was dispatched", async() => {
+    const focusTrap = el.shadowRoot!.querySelector<FocusTrap>("focus-trap");
+    const focusableChild = focusTrap!.querySelector<FocusableChild>("focusable-child");
+
+    focusTrap!["activateFocusTrap"]!();
+    focusTrap!["setFocusableElements"]!();
+
+    await nextFrame();
+    await elementUpdated(el);
+
+    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input");
+    const input = mdInput!.shadowRoot!.querySelector("input");
+
+    input!.click();
+
+    await nextFrame();
+    expect(focusTrap!.focusTrapIndex).toEqual(6);
+    expect(focusTrap!["getDeepActiveElement"]!()).toEqual(input);
+  });
+
+  test("szhould change focus trap index if new focusable element was clicked", async() => {
+    const focusTrap = el.shadowRoot!.querySelector<FocusTrap>("focus-trap");
+    const focusableChild = focusTrap!.querySelector<FocusableChild>("focusable-child");
+    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input");
+    const input = mdInput!.shadowRoot!.querySelector("input");
+
+
+    mdInput!.tabIndex = -1;
+    input!.tabIndex = -1;
+
+    await elementUpdated(el);
+
+    focusTrap!["activateFocusTrap"]!();
+    focusTrap!["setFocusableElements"]!();
+
+    await nextFrame();
+    await elementUpdated(el);
+
+    input!.focus();
+    await nextFrame();
+    await elementUpdated(el);
+
+    expect(focusTrap!["getDeepActiveElement"]!()).toEqual(input);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix issue with tabbing in sequentially and click focusable new elements
## Description
<!--- Describe your changes in detail -->
For controlling the tabbing order for elements that is out of flow with DOM order, focus trap mixin should be cyclical and must be explicitly put non-tabbable elements in tab flow.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
