### PR TITLE
fix(mixin): wait until initial provided element receive focus

### DIFF
--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -325,9 +325,9 @@ export class MenuOverlay extends FocusTrapMixin(LitElement) {
   private focusInsideOverlay() {
     if (this.focusableElements) {
       if (this.focusableElements.length > 1) {
-        this.setFocusableElement!(1);
+        this.setInitialFocus!(1);
       } else if (this.focusableElements.length) {
-        this.setFocusableElement!();
+        this.setInitialFocus!();
       }
     }
   }

--- a/web-components/src/components/modal/Modal.ts
+++ b/web-components/src/components/modal/Modal.ts
@@ -87,7 +87,7 @@ export class Modal extends FocusTrapMixin(LitElement) {
 
   private focusInsideModal() {
     if (this.focusableElements && this.focusableElements.length) {
-      this.setFocusableElement!();
+      this.setInitialFocus!();
     }
   }
 

--- a/web-components/src/mixins/FocusTrapMixin.test.ts
+++ b/web-components/src/mixins/FocusTrapMixin.test.ts
@@ -335,7 +335,7 @@ describe("FocusTrap Mixin", () => {
     await nextFrame();
     await elementUpdated(el);
 
-    focusTrap!["setFocusableElement"]!();
+    focusTrap!["setInitialFocus"]!();
     await nextFrame();
     await elementUpdated(el);
 
@@ -349,6 +349,7 @@ describe("FocusTrap Mixin", () => {
 
     focusTrap!["activateFocusTrap"]!();
     focusTrap!["setFocusableElements"]!();
+    focusTrap!["initialFocusComplete"] = true;
 
     await elementUpdated(focusTrap!);
 
@@ -368,6 +369,7 @@ describe("FocusTrap Mixin", () => {
 
     focusTrap!["activateFocusTrap"]!();
     focusTrap!["setFocusableElements"]!();
+    focusTrap!["initialFocusComplete"] = true;
 
     await nextFrame();
     await elementUpdated(el);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Wait until initial provided element receive focus
## Description
<!--- Describe your changes in detail -->
Element that should receive focus after first browser render cycle now more prioritize 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
