### PR TITLE
fix(web-components): add forgotten component exports

### DIFF
--- a/web-components/src/index.ts
+++ b/web-components/src/index.ts
@@ -6,15 +6,21 @@
  *
  */
 
+export { Accordion } from "./components/accordion/Accordion";
+export { AccordionItem } from "./components/accordion/AccordionItem";
 export { ActivityButton } from "./components/activity-button/ActivityButton";
-export { AlertBanner } from "./components/alert-banner/AlertBanner";
 export { Alert } from "./components/alert/Alert";
+export { AlertBanner } from "./components/alert-banner/AlertBanner";
 export { Avatar } from "./components/avatar/Avatar";
 export { Badge } from "./components/badge/Badge";
+export { Breadcrumb } from "./components/breadcrumb/Breadcrumb";
 export { Button } from "./components/button/Button";
+export { ChatMessage } from "./components/chat-message/ChatMessage";
 export { Checkbox } from "./components/checkbox/Checkbox";
+export { CheckboxGroup } from "./components/checkbox/CheckboxGroup";
 export { Chip } from "./components/chip/Chip";
 export { ComboBox } from "./components/combobox/ComboBox";
+export { CompositeAvatar } from "./components/avatar/CompositeAvatar";
 export { DatePicker } from "./components/datepicker/DatePicker";
 export { DatePickerCalendar } from "./components/datepicker/datepicker-calendar/DatePickerCalendar";
 export { DatePickerDay } from "./components/datepicker/datepicker-day/DatePickerDay";
@@ -37,13 +43,15 @@ export { PhoneInput } from "./components/phone-input/PhoneInput";
 export { ProgressBar } from "./components/progress-bar/ProgressBar";
 export { Radio } from "./components/radio/Radio";
 export { RadioGroup } from "./components/radio/RadioGroup";
+export { Slider } from "./components/slider/Slider";
 export { Spinner } from "./components/spinner/Spinner";
-export { Tab } from "./components/tabs/Tab";
 export { Table } from "./components/table/Table";
+export { Tab } from "./components/tabs/Tab";
 export { TabPanel } from "./components/tabs/TabPanel";
 export { Tabs } from "./components/tabs/Tabs";
 export { TaskItem } from "./components/taskitem/TaskItem";
 export { Theme } from "./components/theme/Theme";
+export { TimePicker } from "./components/timepicker/TimePicker";
 export { ToggleSwitch } from "./components/toggle-switch/ToggleSwitch";
 export { Tooltip } from "./components/tooltip/Tooltip";
 // eslint-disable-next-line prettier/prettier


### PR DESCRIPTION
Exporting all existing components.

## Description
Any component that is not exported is not accessible for people wanting the use our components.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
