### PR TITLE
fix(tabs): add event-listener for close overflow (CAX-839)

### DIFF
--- a/web-components/src/[sandbox]/examples/menu-overlay.ts
+++ b/web-components/src/[sandbox]/examples/menu-overlay.ts
@@ -364,9 +364,9 @@ export const menuOverlayTemplate = html`
           <div style="margin-top:10px">
             <md-radiogroup checked="0">
               <md-radio slot="radio" value="Option 1">Option 1</md-radio>
-              <md-radio slot="radio" value="Option 2">Option 2</md-radio>
+              <!-- <md-radio slot="radio" value="Option 2">Option 2</md-radio>
               <md-radio slot="radio" value="Option 3">Option 3</md-radio>
-              <md-radio slot="radio" value="Option 4">Option 4</md-radio>
+              <md-radio slot="radio" value="Option 4">Option 4</md-radio> -->
             </md-radiogroup>
             <md-input autofocus></md-input>
           </div>

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -283,11 +283,10 @@ export class MenuOverlay extends FocusTrapMixin(LitElement) {
       return;
     }
 
-    if (event.code === Key.Escape) {
+    if (event.code === Key.Escape || event.code === Key.Enter) {
       event.preventDefault();
       if (this.isOpen) {
         this.isOpen = false;
-
         await this.updateComplete;
         this.focusOnTrigger();
       }

--- a/web-components/src/components/tabs/Tabs.ts
+++ b/web-components/src/components/tabs/Tabs.ts
@@ -28,6 +28,7 @@ import { unsafeHTML } from "lit-html/directives/unsafe-html";
 import styles from "./scss/module.scss";
 import { Tab, TabClickEvent, TabKeyDownEvent } from "./Tab";
 import { TabPanel } from "./TabPanel";
+import { MenuOverlay } from "@/components/menu-overlay/MenuOverlay";
 
 type TabViewportData = {
   isTabInViewportHidden: boolean;
@@ -51,6 +52,7 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
   @query('slot[name="panel"]') panelSlotElement?: HTMLSlotElement;
   @query(".md-tab__list[part='tabs-list']") tabsListElement?: HTMLDivElement;
   @query(".md-menu-overlay__more_tab") moreTabMenuElement?: Tab;
+  @query("md-menu-overlay") menuOverlayElement?: MenuOverlay;
 
   @queryAll(".md-menu-overlay__more_list md-tab") tabsCopyHiddenListElements?: NodeListOf<Tab>;
 
@@ -332,6 +334,12 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
     this.updateIsMoreTabMenuSelected();
   }
 
+  handleOverlayClose() {
+    if (this.menuOverlayElement) {
+      this.menuOverlayElement.isOpen = false;
+    }
+  }
+
   handleTabKeydown(event: CustomEvent<TabKeyDownEvent>) {
     const { id, key, ctrlKey, shiftKey, altKey, srcEvent } = event.detail;
 
@@ -568,15 +576,18 @@ export class Tabs extends ResizeMixin(RovingTabIndexMixin(LitElement)) {
               tab => tab.id,
               tab => {
                 return html`
-                  <md-tab
-                    .disabled="${tab.disabled}"
-                    .selected="${tab.selected}"
-                    id="${this.getCopyTabId(tab)}"
-                    aria-controls="${tab.id}"
-                    tabIndex="${this.tabHiddenIdPositiveTabIndex === tab.id ? 0 : -1}"
-                  >
-                    ${unsafeHTML(tab.innerHTML)}
-                  </md-tab>
+
+                    <md-tab
+                      .disabled="${tab.disabled}"
+                      .selected="${tab.selected}"
+                      id="${this.getCopyTabId(tab)}"
+                      aria-controls="${tab.id}"
+                      @click=${this.handleOverlayClose}
+                      tabIndex="${this.tabHiddenIdPositiveTabIndex === tab.id ? 0 : -1}"
+                    >
+                      ${unsafeHTML(tab.innerHTML)}
+                    </md-tab>
+
                 `;
               }
             )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
