### PR TITLE
fix(datepicker): test refactor

### DIFF
--- a/web-components/src/components/datepicker/DatePicker.test.ts
+++ b/web-components/src/components/datepicker/DatePicker.test.ts
@@ -1,5 +1,5 @@
 import { now } from "@/utils/dateUtils";
-import { fixture, fixtureCleanup, html } from "@open-wc/testing-helpers";
+import { elementUpdated, fixture, fixtureCleanup, html } from "@open-wc/testing-helpers";
 import { DateTime } from "luxon";
 import "./DatePicker";
 import { DatePicker } from "./DatePicker";
@@ -26,8 +26,8 @@ describe("DatePicker Component", () => {
     expect(el).not.toBeNull();
   });
   test("should handle date selection update", async () => {
-    const firstDate = now();
-    const secondDate = now().plus({ days: 2 });
+    const firstDate = DateTime.fromObject({ month: 11, day: 15 });
+    const secondDate = firstDate.plus({ days: 2 });
     const el: DatePicker = await fixture(
       html`
         <md-datepicker .selectedDate=${firstDate}></md-datepicker>
@@ -54,23 +54,23 @@ describe("DatePicker Component", () => {
     const selectionFunc = jest.spyOn(el, "handleSelect");
     const navLeft = keyNavEvent("ArrowLeft", startDate);
     el.handleKeyDown(navLeft);
-    await el.updateComplete;
-    expect(el.focusedDate.day).toEqual(startDate.day - 1);
+    await elementUpdated(el);
+    expect(el.focusedDate.ordinal).toEqual(startDate.ordinal - 1);
     const navRight = keyNavEvent("ArrowRight", startDate);
     el.handleKeyDown(navRight);
-    await el.updateComplete;
-    expect(el.focusedDate.day).toEqual(startDate.day);
+    await elementUpdated(el);
+    expect(el.focusedDate.ordinal).toEqual(startDate.ordinal);
     const navUp = keyNavEvent("ArrowUp", startDate);
     el.handleKeyDown(navUp);
-    await el.updateComplete;
-    expect(el.focusedDate.day).toEqual(startDate.day - 7);
+    await elementUpdated(el);
+    expect(el.focusedDate.ordinal).toEqual(startDate.ordinal - 7);
     const navDown = keyNavEvent("ArrowDown", startDate);
     el.handleKeyDown(navDown);
-    await el.updateComplete;
-    expect(el.focusedDate.day).toEqual(startDate.day);
+    await elementUpdated(el);
+    expect(el.focusedDate.ordinal).toEqual(startDate.ordinal);
   });
   test("should select date with keydown events", async () => {
-    const startDate = DateTime.fromObject({ month: 11, day: 15 });
+    const startDate = now();
     const el: DatePicker = await fixture(
       html`
         <md-datepicker .focusedDate=${startDate}></md-datepicker>


### PR DESCRIPTION
This update fixes a brittle DateTime measurement that breaks the tests on end/beginning days of a month. It now uses `ordinal` to compare dates which is not affected by change in months

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
