### PR TITLE
feat(avatar): add part to avatar

### DIFF
--- a/web-components/src/components/avatar/Avatar.ts
+++ b/web-components/src/components/avatar/Avatar.ts
@@ -8,8 +8,8 @@
 
 import "@/components/icon/Icon";
 import "@/components/loading/Loading";
-import reset from "@/wc_scss/reset.scss";
 import { customElementWithCheck } from "@/mixins/CustomElementCheck";
+import reset from "@/wc_scss/reset.scss";
 import { html, internalProperty, LitElement, property } from "lit-element";
 import { nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
@@ -18,8 +18,21 @@ import { styleMap } from "lit-html/directives/style-map";
 import { until } from "lit-html/directives/until.js";
 import styles from "./scss/module.scss";
 
-export const AvatarType = ["active", "bot", "call", "dnd", "group", "inactive", "meeting", "ooo", "presenting", "self", "typing", ""] as const;
-export const AvatarSize = [18, 24, 28, 32, 36, 40, 44, 52, 56, 72, 80, 84]
+export const AvatarType = [
+  "active",
+  "bot",
+  "call",
+  "dnd",
+  "group",
+  "inactive",
+  "meeting",
+  "ooo",
+  "presenting",
+  "self",
+  "typing",
+  ""
+] as const;
+export const AvatarSize = [18, 24, 28, 32, 36, 40, 44, 52, 56, 72, 80, 84];
 
 export namespace Avatar {
   export type Type = typeof AvatarType[number];
@@ -158,7 +171,12 @@ export namespace Avatar {
 
     render() {
       return html`
-        <div class="md-avatar ${classMap(this.avatarClassMap)}" role="img" aria-label=${ifDefined(this.label)}>
+        <div
+          part="avatar"
+          class="md-avatar ${classMap(this.avatarClassMap)}"
+          role="img"
+          aria-label=${ifDefined(this.label)}
+        >
           ${this.type === "self"
             ? html`
                 <span class="md-avatar__self" style=${styleMap(this.avatarStyleMap)}>


### PR DESCRIPTION
This adds a `part` attribute to the rendered Avatar for ease of styling in applied use.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
