### PR TITLE
build(node): remove node version detail to allow for lts

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/momentum-design/momentum-ui/issues"
   },
   "engines": {
-    "node": ">=8 && <=14.15.1",
+    "node": ">=8 && <=14",
     "npm": ">=5"
   },
   "keywords": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed Node version cap from 14.15.1 to 14 to allow for using node LTS

## Related Issue
This is a continuation of issue #745, tidying up a missed consideration
https://github.com/momentum-design/momentum-ui/issues/745 

## Motivation and Context
Allows for using Node 14 LTS in other projects that use momentum-ui/react as a dependency

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
