### PR TITLE
Add usa flag to PhoneInput country code dropdown combobox

### DIFF
--- a/web-components/src/components/phone-input/PhoneInput.test.ts
+++ b/web-components/src/components/phone-input/PhoneInput.test.ts
@@ -1,4 +1,4 @@
-import { fixture, fixtureCleanup, html } from "@open-wc/testing-helpers";
+import { fixture, fixtureCleanup, html, waitUntil } from "@open-wc/testing-helpers";
 import countryCodesList, { customArray } from "country-codes-list";
 import "libphonenumber-js";
 import "./PhoneInput";
@@ -246,6 +246,31 @@ describe("PhoneInput Component", () => {
     element.handleCountryChange(event);
 
     expect(element.shadowRoot?.querySelector('md-combobox')?.classList).toContain("flag__usa");
+  });
+
+  test("should NOT show the US flag when united states is selected from a list", async () => {
+    const element = await fixture<PhoneInput.ELEMENT>(
+      html`
+        <md-phone-input></md-phone-input>
+      `
+    );
+    const classList = element.shadowRoot?.querySelector('md-combobox')?.classList;
+
+    const event: CustomEvent = new CustomEvent("change-selected", {
+      composed: true,
+      bubbles: true,
+      detail: {
+        value: {
+          id: "+1268,AntiguaandBarbuda,AG",
+          value: "+1268"
+        }
+      }
+    }); 
+    element.handleCountryChange(event);
+
+    await waitUntil(() => !classList?.contains('flag__usa'), 'Class "flag__usa" never disappeared');
+
+    expect(classList).not.toContain("flag__usa");
   });
 
 });

--- a/web-components/src/components/phone-input/PhoneInput.test.ts
+++ b/web-components/src/components/phone-input/PhoneInput.test.ts
@@ -205,4 +205,47 @@ describe("PhoneInput Component", () => {
     phoneInput?.dispatchEvent(event);
     expect(keyDownSpy).toHaveBeenCalled();
   });
+
+  test("should show the US flag when default country code is +1", async () => {
+    const element = await fixture(
+      html`
+        <md-phone-input codePlaceholder="+1"></md-phone-input>
+      `
+    );
+
+    expect(element.shadowRoot?.querySelector('md-combobox')?.classList).toContain("flag__usa");
+  });
+
+  test("should not show the US flag when default country code is not +1", async () => {
+    const element = await fixture(
+      html`
+        <md-phone-input codePlaceholder="+7"></md-phone-input>
+      `
+    );
+
+    expect(element.shadowRoot?.querySelector('md-combobox')?.classList).not.toContain("flag__usa");
+  });
+
+  test("should show the US flag when united states is selected from a list", async () => {
+    const element = await fixture<PhoneInput.ELEMENT>(
+      html`
+        <md-phone-input></md-phone-input>
+      `
+    );
+
+    const event: CustomEvent = new CustomEvent("change-selected", {
+      composed: true,
+      bubbles: true,
+      detail: {
+        value: {
+          id: "+1,United States of America,US",
+          value: "+1"
+        }
+      }
+    });
+    element.handleCountryChange(event);
+
+    expect(element.shadowRoot?.querySelector('md-combobox')?.classList).toContain("flag__usa");
+  });
+
 });

--- a/web-components/src/components/phone-input/PhoneInput.ts
+++ b/web-components/src/components/phone-input/PhoneInput.ts
@@ -28,7 +28,7 @@ export namespace PhoneInput {
 
   @customElementWithCheck("md-phone-input")
   export class ELEMENT extends LitElement {
-    @property({ type: String }) codePlaceholder = "+1";
+    @property({ type: String, reflect: true }) codePlaceholder = "+1";
     @property({ type: String }) flagClass = "flag__usa";
     @property({ type: String }) numberPlaceholder = "Enter Phone Number";
     @property({ type: String, attribute: "country-calling-code" }) countryCallingCode = "";
@@ -51,6 +51,22 @@ export namespace PhoneInput {
       });
     }
 
+    attributeChangedCallback(name: string, oldval: any, newval: any) {
+      super.attributeChangedCallback(name, oldval, newval);
+      if(name.toLowerCase() === 'codePlaceholder'.toLowerCase()) {
+        this.flagClass = newval === '+1' ? 'flag_usa' : '';
+      }
+    }
+
+    updated(changedProperties:any) {
+      changedProperties.forEach((oldValue:any, propName:any) => {
+        console.log({propName, x: this});
+        if(propName === 'countryCallingCode'){
+          this.flagClass = this.countryCode === 'US' ? 'flag_usa' : '';
+        }
+      });
+    }
+
     static get styles() {
       return [reset, styles];
     }
@@ -70,17 +86,13 @@ export namespace PhoneInput {
     }
 
     handleCountryChange(event: CustomEvent) {
-      if (!event.detail.value) {
-        this.flagClass = 'flag__usa';
+      this.flagClass = this.codePlaceholder === '+1' ? 'flag__usa' : '';
+      if (!event.detail.value || !event.detail.value.id) {
         return;
       }
       this.countryCallingCode = event.detail.value.id;
       this.countryCode = event.detail.value.id.split(",")[2];
-      if(this.countryCode === "US"){
-        this.flagClass = 'flag__usa';
-      } else {
-        this.flagClass = '';
-      }
+      this.flagClass = this.countryCode === "US" ? 'flag__usa' : '';
     }
 
     handlePhoneChange(event: CustomEvent) {
@@ -147,6 +159,7 @@ export namespace PhoneInput {
             placeholder="${this.codePlaceholder}"
             .value="${this.countryCallingCode ? [this.countryCallingCode] : []}"
             @change-selected="${(e: CustomEvent) => this.handleCountryChange(e)}"
+            @combobox-input="${() => this.flagClass = this.countryCallingCode === '+1' && this.countryCode === 'US' ? 'flag_usa' : ''}"
             with-custom-content
           >
             ${repeat(

--- a/web-components/src/components/phone-input/PhoneInput.ts
+++ b/web-components/src/components/phone-input/PhoneInput.ts
@@ -37,6 +37,7 @@ export namespace PhoneInput {
     @property({ type: String }) value = "";
     @property({ type: String }) errorMessage = "";
 
+    @internalProperty() private countryComboValue: String = "";
     @internalProperty() private countryCode: CountryCode = "US";
     @internalProperty() private codeList = [];
     @internalProperty() private formattedValue = "";
@@ -54,15 +55,14 @@ export namespace PhoneInput {
     attributeChangedCallback(name: string, oldval: any, newval: any) {
       super.attributeChangedCallback(name, oldval, newval);
       if(name.toLowerCase() === 'codePlaceholder'.toLowerCase()) {
-        this.flagClass = newval === '+1' ? 'flag_usa' : '';
+        this.flagClass = newval === '+1' ? 'flag__usa' : '';
       }
     }
 
     updated(changedProperties:any) {
       changedProperties.forEach((oldValue:any, propName:any) => {
-        console.log({propName, x: this});
         if(propName === 'countryCallingCode'){
-          this.flagClass = this.countryCode === 'US' ? 'flag_usa' : '';
+          this.flagClass = this.countryCode === 'US' && (this.countryCallingCode.startsWith('+1') || (this.countryCallingCode === '' && this.codePlaceholder == '+1')) ? 'flag__usa' : '';
         }
       });
     }
@@ -87,6 +87,7 @@ export namespace PhoneInput {
 
     handleCountryChange(event: CustomEvent) {
       this.flagClass = this.codePlaceholder === '+1' ? 'flag__usa' : '';
+      this.countryComboValue = event.detail.value;
       if (!event.detail.value || !event.detail.value.id) {
         return;
       }
@@ -147,6 +148,10 @@ export namespace PhoneInput {
       this.formattedValue = new AsYouType(this.countryCode).input(input);
     }
 
+    handleCountryFocusOut({detail}:any){
+      this.flagClass = (detail.value === '' && this.codePlaceholder === '+1') || (detail.value === '+1' && this.countryCode === 'US' && this.countryCallingCode.startsWith('+1')) ? 'flag__usa' : ''
+    }
+
     render() {
       return html`
         <div class="md-phone-input__container">
@@ -159,7 +164,7 @@ export namespace PhoneInput {
             placeholder="${this.codePlaceholder}"
             .value="${this.countryCallingCode ? [this.countryCallingCode] : []}"
             @change-selected="${(e: CustomEvent) => this.handleCountryChange(e)}"
-            @combobox-input="${() => this.flagClass = this.countryCallingCode === '+1' && this.countryCode === 'US' ? 'flag_usa' : ''}"
+            @combobox-input="${this.handleCountryFocusOut}"
             with-custom-content
           >
             ${repeat(

--- a/web-components/src/components/phone-input/PhoneInput.ts
+++ b/web-components/src/components/phone-input/PhoneInput.ts
@@ -130,7 +130,7 @@ export namespace PhoneInput {
     render() {
       return html`
         <div class="md-phone-input__container">
-          <div class="test-div"><
+          <div part="testDiv" class="test-div"></div>
           <md-combobox
             part="combobox"
             ?disabled=${this.disabled}

--- a/web-components/src/components/phone-input/PhoneInput.ts
+++ b/web-components/src/components/phone-input/PhoneInput.ts
@@ -37,7 +37,6 @@ export namespace PhoneInput {
     @property({ type: String }) value = "";
     @property({ type: String }) errorMessage = "";
 
-    @internalProperty() private countryComboValue: String = "";
     @internalProperty() private countryCode: CountryCode = "US";
     @internalProperty() private codeList = [];
     @internalProperty() private formattedValue = "";
@@ -87,7 +86,6 @@ export namespace PhoneInput {
 
     handleCountryChange(event: CustomEvent) {
       this.flagClass = this.codePlaceholder === '+1' ? 'flag__usa' : '';
-      this.countryComboValue = event.detail.value;
       if (!event.detail.value || !event.detail.value.id) {
         return;
       }

--- a/web-components/src/components/phone-input/PhoneInput.ts
+++ b/web-components/src/components/phone-input/PhoneInput.ts
@@ -130,6 +130,7 @@ export namespace PhoneInput {
     render() {
       return html`
         <div class="md-phone-input__container">
+          <div class="test-div"><
           <md-combobox
             part="combobox"
             ?disabled=${this.disabled}

--- a/web-components/src/components/phone-input/PhoneInput.ts
+++ b/web-components/src/components/phone-input/PhoneInput.ts
@@ -23,11 +23,13 @@ export namespace PhoneInput {
     pill: boolean;
     value: string;
     errorMessage: string;
+    flagClass: string;
   };
 
   @customElementWithCheck("md-phone-input")
   export class ELEMENT extends LitElement {
     @property({ type: String }) codePlaceholder = "+1";
+    @property({ type: String }) flagClass = "flag__usa";
     @property({ type: String }) numberPlaceholder = "Enter Phone Number";
     @property({ type: String, attribute: "country-calling-code" }) countryCallingCode = "";
     @property({ type: Boolean }) pill = false;
@@ -69,10 +71,16 @@ export namespace PhoneInput {
 
     handleCountryChange(event: CustomEvent) {
       if (!event.detail.value) {
+        this.flagClass = 'flag__usa';
         return;
       }
       this.countryCallingCode = event.detail.value.id;
       this.countryCode = event.detail.value.id.split(",")[2];
+      if(this.countryCode === "US"){
+        this.flagClass = 'flag__usa';
+      } else {
+        this.flagClass = '';
+      }
     }
 
     handlePhoneChange(event: CustomEvent) {
@@ -132,6 +140,7 @@ export namespace PhoneInput {
         <div class="md-phone-input__container">
           <div part="testDiv" class="test-div"></div>
           <md-combobox
+            class="${this.flagClass}"
             part="combobox"
             ?disabled=${this.disabled}
             shape="${this.pill ? "pill" : "none"}"

--- a/web-components/src/components/phone-input/scss/phoneInput.scss
+++ b/web-components/src/components/phone-input/scss/phoneInput.scss
@@ -3,6 +3,13 @@
   display: flex;
   position: relative;
 
+  .test-div {
+    height: 100px;
+    width: 20px;
+    background: url('/images/flags.png') -5220px 0;
+    background-repeat: no-repeat;
+  }
+
   md-combobox {
     width: var(--combo-box-contaier-width);
   }

--- a/web-components/src/components/phone-input/scss/phoneInput.scss
+++ b/web-components/src/components/phone-input/scss/phoneInput.scss
@@ -3,7 +3,7 @@
   display: flex;
   position: relative;
 
-  md-combobox {
+  md-combobox.flag__usa {
     &::part(multiwrap) {
       &:before {
           content: '';

--- a/web-components/src/components/phone-input/scss/phoneInput.scss
+++ b/web-components/src/components/phone-input/scss/phoneInput.scss
@@ -3,11 +3,19 @@
   display: flex;
   position: relative;
 
-  .test-div {
-    height: 100px;
-    width: 20px;
-    background: url('/images/flags.png') -5220px 0;
-    background-repeat: no-repeat;
+  md-combobox {
+    &::part(multiwrap) {
+      &:before {
+          content: '';
+          height: 10px;
+          width: 20px;
+          background: url('/images/flags.png') -5220px 0;
+          background-repeat: no-repeat;
+        }
+      }
+      &::part(multiwrap-input) {
+        flex: 1;
+      }
   }
 
   md-combobox {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In the PhoneInput component there is a combobox that lists country codes. This adds the usa flag when the US country code is selected

## Related Issue
https://github.com/momentum-design/momentum-ui/issues/827

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New Unit tests Added. Changes tested in Firefox and Chrome browser.

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->
<img width="385" alt="noFlag" src="https://user-images.githubusercontent.com/79867310/111532290-7de25980-8733-11eb-84e2-30f7641e73ba.png">

**After**:
<!--- Please add after images, gifs or videos here: -->
<img width="359" alt="countryFlag" src="https://user-images.githubusercontent.com/79867310/111532376-95b9dd80-8733-11eb-9c31-83514f96ff1f.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
