### PR TITLE
fix(tooltips): fix tooltips for lightbox

### DIFF
--- a/react/src/lib/EventOverlay/index.js
+++ b/react/src/lib/EventOverlay/index.js
@@ -472,7 +472,7 @@ class EventOverlay extends React.Component {
     const documentScrollTop = document.documentElement.scrollTop;
     const documentBottom = document.documentElement.scrollHeight;
     const windowBottom = window.pageXOffset + window.innerHeight;
-    const documentRight = document.documentElement.offsetWidth;
+    const documentRight = Math.max(document.documentElement.offsetWidth, document.documentElement.clientWidth);
     const arrowHeight = (arrowDims && arrowDims.height) || 0;
     const arrowWidth = (arrowDims && arrowDims.width) || 0;
     const offsetHeight = targetOffset.vertical || 0;
@@ -610,7 +610,7 @@ class EventOverlay extends React.Component {
           if (elementDims.right >= documentRight || this.elementWidth > documentRight) {
             targetNode.style.right = '0px';
             if (this.elementWidth < documentRight) {
-              targetNode.style.left = 'revert';
+              targetNode.style.left = 'inherit';
             }
           }
           if (elementDims.left < 0) {
@@ -686,19 +686,14 @@ class EventOverlay extends React.Component {
         break;
       case 'left':
         if (!scrollParentDims.left && !transformParentDims) {
-          if (
-            arrowWidth + offsetWidth + elementDims.width + anchorPosition.left >
-            anchorPosition.left
-          ) {
-            if (anchorPosition.left  - offsetWidth - elementDims.width > arrowWidth) {
-              targetNode.style.left = 'revert';
-            } else {
-              targetNode.style.left = `${arrowWidth}px`;
-            }
-            targetNode.style.right = `${documentRight -
-              anchorPosition.left +
-              arrowWidth +
-              offsetWidth}px`;
+          targetNode.style.right = `${documentRight -
+            anchorPosition.left +
+            arrowWidth +
+            offsetWidth}px`;
+          if ( elementDims.left - arrowWidth < 0 ) {
+            targetNode.style.left = `${arrowWidth}px`;
+          } else {
+            targetNode.style.left = 'inherit';
           }
           if (getAvailableTopSpace(documentScrollTop) < 0) {
             targetNode.style.top = `${-documentScrollTop}px`;

--- a/react/src/lib/EventOverlay/index.js
+++ b/react/src/lib/EventOverlay/index.js
@@ -690,7 +690,15 @@ class EventOverlay extends React.Component {
             arrowWidth + offsetWidth + elementDims.width + anchorPosition.left >
             anchorPosition.left
           ) {
-            targetNode.style.left = `${anchorPosition.left - elementDims.width - offsetWidth}px`;
+            if (anchorPosition.left  - offsetWidth - elementDims.width > arrowWidth) {
+              targetNode.style.left = 'revert';
+            } else {
+              targetNode.style.left = `${arrowWidth}px`;
+            }
+            targetNode.style.right = `${documentRight -
+              anchorPosition.left +
+              arrowWidth +
+              offsetWidth}px`;
           }
           if (getAvailableTopSpace(documentScrollTop) < 0) {
             targetNode.style.top = `${-documentScrollTop}px`;

--- a/react/src/lib/EventOverlay/index.js
+++ b/react/src/lib/EventOverlay/index.js
@@ -607,10 +607,10 @@ class EventOverlay extends React.Component {
           ) {
             targetNode.style.bottom = `${documentScrollTop + windowBottom - documentBottom}px`;
           }
-          if (elementDims.right > documentRight || this.elementWidth > documentRight) {
+          if (elementDims.right >= documentRight || this.elementWidth > documentRight) {
             targetNode.style.right = '0px';
             if (this.elementWidth < documentRight) {
-              targetNode.style.left = `${documentRight - this.elementWidth}px`;
+              targetNode.style.left = 'revert';
             }
           }
           if (elementDims.left < 0) {
@@ -690,11 +690,7 @@ class EventOverlay extends React.Component {
             arrowWidth + offsetWidth + elementDims.width + anchorPosition.left >
             anchorPosition.left
           ) {
-            targetNode.style.left = `${arrowWidth}px`;
-            targetNode.style.right = `${documentRight -
-              anchorPosition.left +
-              arrowWidth +
-              offsetWidth}px`;
+            targetNode.style.left = `${anchorPosition.left - elementDims.width - offsetWidth}px`;
           }
           if (getAvailableTopSpace(documentScrollTop) < 0) {
             targetNode.style.top = `${-documentScrollTop}px`;

--- a/react/src/lib/Lightbox/index.js
+++ b/react/src/lib/Lightbox/index.js
@@ -332,7 +332,7 @@ class Lightbox extends React.Component {
 
 
     const leftArrowControl = (
-      <Tooltip tooltip={tooltips.previous} direction="right-center">
+      <Tooltip tooltip={tooltips.previous} popoverProps={{direction: "right-center", isContained: true}}>
         <div
           className="md-lightbox__page-control md-lightbox__page-control-icon md-lightbox__page-controls--left"
           role="button"
@@ -347,7 +347,7 @@ class Lightbox extends React.Component {
     );
 
     const rightArrowControl = (
-      <Tooltip tooltip={tooltips.next} direction="left-center">
+      <Tooltip tooltip={tooltips.next} popoverProps={{direction: "left-center", isContained: true}}>
         <div
           className="md-lightbox__page-control md-lightbox__page-control-icon md-lightbox__page-controls--right"
           role="button"

--- a/react/src/lib/Popover/examples/Direction.js
+++ b/react/src/lib/Popover/examples/Direction.js
@@ -1,20 +1,32 @@
 import React from 'react';
+import PropTypes from 'prop-types';
  import {
   Button,
   Popover
 } from '@momentum-ui/react';
- export default function PopOverDirection() {
+ export default function PopOverDirection({direction, isContained}) {
+    const testCase = `This is a really long popover ${direction} - isContained: ${isContained ? "true" : "false"}`;
     const content = (
-    <span key="1" style={{ padding: '10px'}}>right-center</span>
+    <span key="1" style={{ padding: '10px'}}>{testCase}</span>
   );
   return (
     <div className="docs-example docs-example--spacing">
       <Popover
         content={content}
-        direction={'right-center'}
+        direction={direction}
+        isContained={isContained}
       >
-        <Button id='direction' children='Direction' ariaLabel='Direction' />
+        <Button id={`direction_${direction}_${isContained}`} children={`Direction: ${testCase}`} ariaLabel='Direction' />
       </Popover>
     </div>
   );
 }
+
+PopOverDirection.propTypes = {
+  direction: PropTypes.string,
+  isContained: PropTypes.bool
+};
+
+PopOverDirection.defaultProps = {
+  isContained: false
+};

--- a/react/src/lib/Popover/examples/KitchenSink.js
+++ b/react/src/lib/Popover/examples/KitchenSink.js
@@ -17,7 +17,14 @@ export default class PopoverKitchenSink extends React.Component {
         <PopoverArrow />
         <PopoverContained />
         <PopoverDefault />
-        <PopoverDirection />
+        <PopoverDirection direction={'right-center'} />
+        <PopoverDirection direction={'left-center'} />
+        <PopoverDirection direction={'top-center'} />
+        <PopoverDirection direction={'bottom-center'} />
+        <PopoverDirection direction={'right-center'} isContained={true} />
+        <PopoverDirection direction={'left-center'} isContained={true}/>
+        <PopoverDirection direction={'top-center'} isContained={true} />
+        <PopoverDirection direction={'bottom-center'} isContained={true} />
         <PopoverOffset />
         <PopoverOverflow />
       </React.Fragment>

--- a/react/src/lib/Popover/tests/index.cy.js
+++ b/react/src/lib/Popover/tests/index.cy.js
@@ -60,13 +60,13 @@ describe('@momentum-ui/react', () => {
 
   forEach([true, false], (isContained) => {
     forEach(['top', 'bottom', 'left', 'right'], (direction) => {
-      it('snapshot of direction popover', () => {
+      it(`snapshot of direction: ${direction}, isContained: ${isContained} popover`, () => {
         cy.get(`#direction_${direction}_${isContained}`)
-            .focus()
-            .get(`.${prefix}-event-overlay`)
-            .should('exist')
-            .percySnapshot()
-            .end();
+          .focus()
+          .get(`.${prefix}-event-overlay`)
+          .should('exist')
+          .percySnapshot()
+          .end();
       });
     });
   });

--- a/react/src/lib/Popover/tests/index.cy.js
+++ b/react/src/lib/Popover/tests/index.cy.js
@@ -59,7 +59,7 @@ describe('@momentum-ui/react', () => {
   });
 
   forEach([true, false], (isContained) => {
-    forEach(['top', 'bottom', 'left', 'right'], (direction) => {
+    forEach(['top-center', 'bottom-center', 'left-center', 'right-center'], (direction) => {
       it(`snapshot of direction: ${direction}, isContained: ${isContained} popover`, () => {
         cy.get(`#direction_${direction}_${isContained}`)
           .focus()

--- a/react/src/lib/Popover/tests/index.cy.js
+++ b/react/src/lib/Popover/tests/index.cy.js
@@ -1,4 +1,5 @@
 import { prefix } from '../../utils/index';
+import { forEach } from 'lodash';
 
 describe('@momentum-ui/react', () => {
   before(() => {
@@ -57,13 +58,17 @@ describe('@momentum-ui/react', () => {
       .end();
   });
 
-  it('snapshot of direction popover', () => {
-    cy.get('#direction')
-        .focus()
-        .get(`.${prefix}-event-overlay`)
-        .should('exist')
-        .percySnapshot()
-        .end();
+  forEach([true, false], (isContained) => {
+    forEach(['top', 'bottom', 'left', 'right'], (direction) => {
+      it('snapshot of direction popover', () => {
+        cy.get(`#direction_${direction}_${isContained}`)
+            .focus()
+            .get(`.${prefix}-event-overlay`)
+            .should('exist')
+            .percySnapshot()
+            .end();
+      });
+    });
   });
 
   it('snapshot of offset popover', () => {

--- a/react/src/lib/Tooltip/examples/Direction.js
+++ b/react/src/lib/Tooltip/examples/Direction.js
@@ -3,14 +3,97 @@ import { Button, Tooltip } from '@momentum-ui/react';
 
 export default function TooltipDirection() {
   return (
-    <div className="docs-example docs-example--spacing">
-      <Tooltip
-        tooltip="Hello!"
-        tooltipTrigger="Click"
-        popoverProps={{ direction: 'right-center' }}
-      >
-        <Button id='direction' children="Direction" ariaLabel="Direction" />
-      </Tooltip>
+    <div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'right-center' }}
+        >
+          <Button id='direction' children="Direction right" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'right-center', isContained: true }}
+        >
+          <Button id='direction' children="Direction right - contained" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'left-center', isContained: true }}
+        >
+          <Button id='direction' children="Direction left" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'left-center', isContained: true }}
+        >
+          <Button id='direction' children="Direction left - contained" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'top-center'}}
+        >
+          <Button id='direction' children="Direction top" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'top-center', isContained: true }}
+        >
+          <Button id='direction' children="Direction top - contained" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'bottom-center'}}
+        >
+          <Button id='direction' children="Direction bottom" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing">
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'bottom-center', isContained: true }}
+        >
+          <Button id='direction' children="Direction bottom - contained" ariaLabel="Direction" />
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing" style={{position: 'fixed', right: 0, padding: '0 !important'}}>
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'bottom-center', isContained: true }}
+        >
+          <div style={{width: "1rem"}}>X</div>
+        </Tooltip>
+      </div>
+      <div className="docs-example docs-example--spacing" style={{position: 'fixed', left: 0, padding: '0 !important'}}>
+        <Tooltip
+          tooltip="Hello!"
+          tooltipTrigger="Click"
+          popoverProps={{ direction: 'bottom-center', isContained: true }}
+        >
+          <div style={{width: "1rem"}}>X</div>
+        </Tooltip>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fix a few issues with the event overlay which are noticeable on the lightbox tooltips

## Description
When the isContained flag is true, both bottom and left positioned overlays were broken. The bottom positioning was broken when the element is on the far right of the page. The left positioned overlay would stretch to the far left of the page.

In addition, the props for the tooltips in the lightbox were being specified incorrectly. The Tooltip component does not take a direction property, instead taking a popoverProps object.

In the EventOverlay component, reliance on documentRight for positioning is broken in the presence of a scrollbar. I've removed this problem by no longer relying on documentRight for the bottom or left contained positioning.

## Related Issue
#848

## Motivation and Context
Fixes light box tooltips

## How Has This Been Tested?
Checked visually on the lightbox and tooltip kitchen sink components along with every other component that uses lightbox. I've also added some more cases to the tooltip direction kitchen sink

## Screenshots:
**Before**:
![lightbox_before](https://user-images.githubusercontent.com/3998548/114016268-94775e80-9862-11eb-9260-b5eadf518bb3.png)


**After**:
![lightbox_after](https://user-images.githubusercontent.com/3998548/114015521-af959e80-9861-11eb-89cb-ae0a4ddeda05.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
