### PR TITLE
fix(core/alert): transparent backgrounds

### DIFF
--- a/core/scss/components/alert/alert.scss
+++ b/core/scss/components/alert/alert.scss
@@ -118,7 +118,7 @@
     }
 
     &.#{$alert__class}--success {
-      background-color: var(--md-alert-background-success, transparent);
+      background-color: var(--md-alert-background-success, $md-white-100);
 
       .#{$alert__class}__icon {
         &:before {
@@ -136,7 +136,7 @@
     }
 
     &.#{$alert__class}--warning {
-      background-color: var(--md-alert-background-warning, transparent);
+      background-color: var(--md-alert-background-warning, $md-white-100);
 
       .#{$alert__class}__icon {
         &:before {
@@ -154,7 +154,7 @@
     }
 
     &.#{$alert__class}--error {
-      background-color: var(--md-alert-background-error, transparent);
+      background-color: var(--md-alert-background-error, $md-white-100);
 
       .#{$alert__class}__icon {
         &:before {


### PR DESCRIPTION
# Description

Hotfix to fix transparent backgrounds on alerts without theming.

# Screenshots

![Screen Shot 2021-04-19 at 5 18 06 PM](https://user-images.githubusercontent.com/14828820/115305166-ee660700-a133-11eb-83c1-e8bfcfa1e673.png)
