### PR TITLE
fix(menu-overlay): restore functionality

### DIFF
--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -7,15 +7,15 @@
  */
 
 import { Key } from "@/constants";
+import { customElementWithCheck } from "@/mixins/CustomElementCheck";
+import { FocusTrapMixin } from "@/mixins/FocusTrapMixin";
 import { Placement } from "@popperjs/core/lib";
 import arrow from "@popperjs/core/lib/modifiers/arrow";
 import flip from "@popperjs/core/lib/modifiers/flip";
 import offset from "@popperjs/core/lib/modifiers/offset";
 import preventOverflow from "@popperjs/core/lib/modifiers/preventOverflow";
 import { createPopper, defaultModifiers, Instance, Rect } from "@popperjs/core/lib/popper-lite";
-import { customElementWithCheck } from "@/mixins/CustomElementCheck";
 import { html, LitElement, property, PropertyValues, query, queryAssignedNodes } from "lit-element";
-import { FocusTrapMixin } from "@/mixins/FocusTrapMixin";
 import styles from "./scss/module.scss";
 
 export enum OverlaySizes {
@@ -263,7 +263,6 @@ export namespace MenuOverlay {
     }
 
     private handleTriggerClick = (event: MouseEvent) => {
-      event.stopPropagation();
       this.toggleOverlay();
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

RE: https://jira-eng-sjc12.cisco.com/jira/browse/CAX-944

It is unclear why/how Card uses a persisting menu, and since it causes MenuOverlay to break elsewhere, I suggest keeping the overly behavior to close when another menu is opened.

## Description
<!--- Describe your changes in detail -->
Remove `event.stopPropogation()` from Menu Overlay's `handleTriggerClick` method.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
