### PR TITLE
feat(core/button): add base theming

### DIFF
--- a/core/scss/components/button/button.scss
+++ b/core/scss/components/button/button.scss
@@ -20,7 +20,18 @@
       $padding: $button__padding--36,
       $radius: $button__radius--36
     );
-    @include button-color($focus: true);
+    @include button-color(
+      $bg-css-var: --md-button-secondary-bg-color,
+      $bg-active-css-var: --md-button-secondary-pressed-bg-color,
+      $bg-disabled-css-var: --md-button-disabled-bg-color,
+      $bg-hover-css-var: --md-button-secondary-hover-bg-color,
+      $border-focus-css-var: --md-button-focus-ring-color,
+      $color-css-var: --md-button-secondary-text-color,
+      $color-active-css-var: --md-button-secondary-text-color,
+      $color-disabled-css-var: --md-button-disabled-text-color,
+      $color-hover-css-var: --md-button-secondary-text-color,
+      $focus: true
+    );
     @include single-transition(
       background-color,
       $button__transition-speed,
@@ -247,6 +258,15 @@
 
       &--blue {
         @include button-color(
+          $bg-css-var: --md-button-primary-bg-color,
+          $bg-active-css-var: --md-button-primary-pressed-bg-color,
+          $bg-disabled-css-var: --md-button-disabled-bg-color,
+          $bg-hover-css-var: --md-button-primary-hover-bg-color,
+          $border-focus-css-var: --md-button-focus-ring-color,
+          $color-css-var: --md-button-primary-text-color,
+          $color-active-css-var: --md-button-primary-text-color,
+          $color-disabled-css-var: --md-button-disabled-text-color,
+          $color-hover-css-var: --md-button-primary-text-color,
           $color: $button__font-color--alt,
           $bg: $button--blue__background-color,
           $bg-hover: $button--blue__background-color--hover,
@@ -255,8 +275,8 @@
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -272,27 +292,46 @@
 
       &--blue-outline {
         @include button-color(
-          $color: $button--blue__background-color,
           $bg: $button--white__background-color,
-          $border: 1px solid $button--blue__background-color,
-          $color-hover: $button__font-color--alt,
+          $bg-css-var: --md-background-primary,
+          $bg-active: $button--blue__background-color--active,
+          $bg-active-css-var: --md-button-primary-pressed-bg-color,
+          $bg-disabled-css-var: --md-button-disabled-bg-color,
           $bg-hover: $button--blue__background-color--hover,
-          $bg-active: $button--blue__background-color--active
+          $bg-hover-css-var: --md-button-primary-hover-bg-color,
+          $border: 1px solid,
+          $border-color: $button--blue__background-color,
+          $border-color-css-var: --md-button-primary-outline-color,
+          $color: $button--blue__background-color,
+          $color-css-var: --md-button-primary-outline-text-color,
+          $color-active-css-var: --md-button-primary-text-color,
+          $color-disabled: --md-button-disabled-text-color,
+          $color-hover: $button__font-color--alt,
+          $color-hover-css-var: --md-button-primary-text-color
         );
       }
 
       &--red {
         @include button-color(
-          $color: $button__font-color--alt,
           $bg: $button--red__background-color,
+          $bg-css-var: --md-button-cancel-bg-color,
+          $bg-active: $button--red__background-color--active,
+          $bg-active-css-var: --md-button-cancel-pressed-bg-color,
+          $bg-disabled-css-var: --md-button-disabled-bg-color,
           $bg-hover: $button--red__background-color--hover,
-          $bg-active: $button--red__background-color--active
+          $bg-hover-css-var: --md-button-cancel-hover-bg-color,
+          $border-focus-css-var: --md-button-focus-ring-color,
+          $color: $button__font-color--alt,
+          $color-css-var: --md-button-cancel-text-color,
+          $color-active-css-var: --md-button-cancel-text-color,
+          $color-disabled-css-var: --md-button-disabled-text-color,
+          $color-hover-css-var: --md-button-cancel-text-color
         );
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -308,16 +347,25 @@
 
       &--green {
         @include button-color(
-          $color: $button__font-color--alt,
           $bg: $button--green__background-color,
+          $bg-css-var: --md-button-join-bg-color,
+          $bg-active: $button--green__background-color--active,
+          $bg-active-css-var: --md-button-join-pressed-bg-color,
+          $bg-disabled-css-var: --md-button-disabled-bg-color,
           $bg-hover: $button--green__background-color--hover,
-          $bg-active: $button--green__background-color--active
+          $bg-hover-css-var: --md-button-join-hover-bg-color,
+          $border-focus-css-var: --md-button-focus-ring-color,
+          $color: $button__font-color--alt,
+          $color-css-var: --md-button-join-text-color,
+          $color-active-css-var: --md-button-join-text-color,
+          $color-disabled-css-var: --md-button-disabled-text-color,
+          $color-hover-css-var: --md-button-join-text-color
         );
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -341,8 +389,8 @@
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -366,8 +414,8 @@
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -391,8 +439,8 @@
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -416,8 +464,8 @@
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -441,8 +489,8 @@
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -466,8 +514,8 @@
 
         .#{$dark-class} & {
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
         }
 
@@ -495,8 +543,8 @@
           box-shadow: none;
 
           @include button-color-disabled(
-            $button__font-color--disabled--dark,
-            $button__color--disabled--dark
+            $color: $button__font-color--disabled--dark,
+            $bg: $button__color--disabled--dark
           );
           @include button-color-focus;
         }

--- a/core/scss/components/button/mixins.scss
+++ b/core/scss/components/button/mixins.scss
@@ -105,83 +105,126 @@
 
 @mixin button-color(
   $bg: $button__background-color,
+  $bg-css-var: null,
   $bg-active: $button__background-color--active,
+  $bg-active-css-var: null,
   $bg-disabled: $button__color--disabled,
+  $bg-disabled-css-var: null,
   $bg-hover: $button__background-color--hover,
+  $bg-hover-css-var: null,
   $border: false,
+  $border-color: null,
+  $border-color-css-var: null,
   $border-hover: false,
+  $border-hover-css-var: null,
   $border-active: false,
+  $border-active-css-var: null,
   $border-focus: $button__border-color--focus,
+  $border-focus-css-var: null,
   $box-shadow: false,
+  $box-shadow-css-var: null,
   $color: $button__font-color,
+  $color-css-var: null,
   $color-active: $color,
+  $color-active-css-var: null,
   $color-disabled: $button__font-color--disabled,
+  $color-disabled-css-var: null,
   $color-hover: $color,
+  $color-hover-css-var: null,
   $disabled: true,
   $focus: false,
   $opacity: false,
-  $outline: false
+  $opacity-css-var: null,
+  $outline: false,
+  $outline-css-var: null
 ) {
   color: $color;
+  color: var($color-css-var, $color);
   background-color: $bg;
+  background-color: var($bg-css-var, $bg);
   border-color: transparent;
 
   @if $border {
     border: $border;
+    border-color: var($border-color-css-var, $border-color);
   }
 
   @if $box-shadow {
     box-shadow: $box-shadow;
+    box-shadow: var($box-shadow-css-var, $box-shadow);
   }
 
   @if $disabled {
     @include button-color-disabled(
       $color: $color-disabled,
+      $color-css-var: $color-disabled-css-var,
       $bg: $bg-disabled,
-      $opacity: $opacity
+      $bg-css-var: $bg-disabled-css-var,
+      $opacity: $opacity,
+      $opacity-css-var: $opacity-css-var
     );
   }
 
   @if $focus {
-    @include button-color-focus($border-focus);
+    @include button-color-focus(
+      $color: $border-focus,
+      $color-css-var: $color-css-var
+    );
   }
 
   @if $outline {
     outline: $outline;
+    outline: var($outline-css-var, $outline);
   }
 
   &:hover {
     color: $color-hover;
+    color: var($color-hover-css-var, $color-hover);
     background-color: $bg-hover;
+    background-color: var($bg-hover-css-var, $bg-hover);
 
     @if $border-hover {
       border: $border-hover;
+      border: var($border-hover-css-var, $border-hover);
     }
   }
 
   &:active,
   &.active {
     color: $color-active;
+    color: var($color-active-css-var, $color-active);
     background-color: $bg-active;
+    background-color: var($bg-active-css-var, $bg-active);
 
     @if $border-active {
       border: $border-active;
+      border: var($border-active-css-var, $border-active);
     }
   }
 }
 
 @mixin button-color-fill(
   $fill: $button__font-color,
+  $fill-css-var: null,
   $fill-hover: $fill,
+  $fill-hover-css-var: null,
   $fill-active: $color,
+  $fill-active-css-var: null,
   $fill-disabled: $button__font-color--disabled,
+  $fill-disabled-css-var: null,
   $bg-disabled: transparent,
+  $bg-disabled-css-var: null,
   $focus: false
 ) {
   fill: $fill;
   color: $fill;
 
-  @include button-color-disabled($color: $fill-disabled, $bg: $bg-disabled);
+  @include button-color-disabled(
+    $color: $fill-disabled,
+    $color-css-var: $fill-disabled-css-var,
+    $bg: $bg-disabled,
+    $bg-css-var: $bg-disabled
+  );
 
   @if $focus {
     @include button-color-focus;
@@ -200,7 +243,10 @@
   }
 }
 
-@mixin button-color-focus($color: $button__border-color--focus) {
+@mixin button-color-focus(
+  $color: $button__border-color--focus,
+  $color-css-var: null
+) {
   &:focus,
   &.focus-state {
     @include focus-styles;
@@ -209,8 +255,11 @@
 
 @mixin button-color-disabled(
   $color: $button__font-color--disabled,
+  $color-css-var: null,
   $bg: $button__color--disabled,
-  $opacity: false
+  $bg-css-var: null,
+  $opacity: false,
+  $opacity-css-var: null
 ) {
   &.disabled,
   &.md-button--disabled,
@@ -219,15 +268,21 @@
       opacity: $opacity;
     } @else {
       color: $color;
+      color: var($color-css-var, $color);
       fill: $color;
+      fill: var($color-css-var, $color);
       background-color: $bg;
+      background-color: var($bg-css-var, $bg);
     }
 
     &:hover,
     &:focus {
       color: $color;
+      color: var($color-css-var, $color);
       fill: $color;
+      fill: var($color-css-var, $color);
       background-color: $bg;
+      background-color: var($bg-css-var, $bg);
     }
   }
 }


### PR DESCRIPTION
## Description

The scope of the changes in this pull request are adding the core button theming based on the latest Figma for the `Button` component. This changes are scoped to what is needed at the core of the Web Client.

## Related Issue
[SPARK-218760](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-218760)

## Motivation and Context
The changes in this pull request are required to meet the release of Dark/Light mode in the Web Client.

## How Has This Been Tested?
Live visual testing using Kitchen Sink.

## Screenshots:

### Before / No Theming Enabled

![Screen Shot 2021-04-30 at 4 57 21 PM](https://user-images.githubusercontent.com/14828820/116881458-47807100-abf1-11eb-8fdb-1aaf91278c76.png)

### After / With Theming

#### Dark
![Screen Shot 2021-04-30 at 4 57 39 PM](https://user-images.githubusercontent.com/14828820/116881500-5404c980-abf1-11eb-9ebc-05c68c4d9a2f.png)

#### Light

![Screen Shot 2021-04-30 at 4 57 30 PM](https://user-images.githubusercontent.com/14828820/116881503-55ce8d00-abf1-11eb-9402-bd4eaa3bcfc7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
