### PR TITLE
feat(core/event-overlay): add theming

### DIFF
--- a/core/scss/components/overlay/event-overlay.scss
+++ b/core/scss/components/overlay/event-overlay.scss
@@ -9,7 +9,9 @@
       position: fixed;
       z-index: $zindex-top-bar-fixed - 4;
       display: flex;
-      background: $md-white-100;
+      color: $md-gray-90;
+      color: var(--md-textColor-primary, $md-gray-90);
+      background: var(--md-background-primary, $md-white-100);
       border-radius: $event-overlay__border-radius;
       box-shadow: $event-overlay__border, $event-overlay__shadow;
 
@@ -58,6 +60,7 @@
         border-left: $arrow-width solid transparent;
         border-right: $arrow-width solid transparent;
         border-top: $event-overlay-arrow__height solid $event-overlay__border-color;
+        border-top: $event-overlay-arrow__height solid var(--md-background-quaternary, $event-overlay__border-color);
         margin-left: -$arrow-width;
         margin-top: -$event-overlay-arrow__height - 1;
 
@@ -65,6 +68,7 @@
           border-left: $arrow-top-layer-width solid transparent;
           border-right: $arrow-top-layer-width solid transparent;
           border-top: $arrow-top-layer-height solid $md-white-100;
+          border-top: $arrow-top-layer-height solid var(--md-background-primary, $md-white-100);
           bottom: $arrow-layer-spacing;
           left: -$arrow-top-layer-width;
         }
@@ -73,6 +77,7 @@
       .#{$prefix}-event-overlay--left > & {
         border-bottom: $arrow-width solid transparent;
         border-left: $event-overlay-arrow__height solid $event-overlay__border-color;
+        border-left: $event-overlay-arrow__height solid var(--md-background-quaternary, $event-overlay__border-color);
         border-top: $arrow-width solid transparent;
         margin-left: -$event-overlay-arrow__height - 1;
         margin-top: -$arrow-width;
@@ -80,6 +85,7 @@
         &::after {
           border-bottom: $arrow-top-layer-width solid transparent;
           border-left: $arrow-top-layer-height solid $md-white-100;
+          border-left: $arrow-top-layer-height solid var(--md-background-primary, $md-white-100);
           border-top: $arrow-top-layer-width solid transparent;
           right: $arrow-layer-spacing;
           top: -$arrow-top-layer-width;
@@ -89,6 +95,7 @@
       .#{$prefix}-event-overlay--right > & {
         border-bottom: $arrow-width solid transparent;
         border-right: $event-overlay-arrow__height solid $event-overlay__border-color;
+        border-right: $event-overlay-arrow__height solid var(--md-background-quaternary, $event-overlay__border-color);
         border-top: $arrow-width solid transparent;
         margin-left: 1px;
         margin-top: -$arrow-width;
@@ -96,6 +103,7 @@
         &::after {
           border-bottom: $arrow-top-layer-width solid transparent;
           border-right: $arrow-top-layer-height solid $md-white-100;
+          border-right: $arrow-top-layer-height solid var(--md-background-primary, $md-white-100);
           border-top: $arrow-top-layer-width solid transparent;
           left: $arrow-layer-spacing;
           top: -$arrow-top-layer-width;
@@ -104,6 +112,7 @@
 
       .#{$prefix}-event-overlay--bottom > & {
         border-bottom: $event-overlay-arrow__height solid $event-overlay__border-color;
+        border-bottom: $event-overlay-arrow__height solid var(--md-background-quaternary, $event-overlay__border-color);
         border-left: $arrow-width solid transparent;
         border-right: $arrow-width solid transparent;
         margin-left: -$arrow-width;
@@ -111,6 +120,7 @@
 
         &::after {
           border-bottom: $arrow-top-layer-height solid $md-white-100;
+          border-bottom: $arrow-top-layer-height solid var(--md-background-primary, $md-white-100);
           border-left: $arrow-top-layer-width solid transparent;
           border-right: $arrow-top-layer-width solid transparent;
           left: -$arrow-top-layer-width;


### PR DESCRIPTION
## Description

The scope of the changes in this pull request are to add theming support to the `event-overlay`, which adds theme changes to the `pop-over` component [core].

## Related Issue

[SPARK-233818](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-233818)

## Motivation and Context

This adds theming to the component as per the requirement for Web Client.

## How Has This Been Tested?

Visual testing was done to validate changes

## Screenshots:

### Default

![Screen Shot 2021-05-19 at 10 13 50 PM](https://user-images.githubusercontent.com/14828820/118909627-49d11380-b8f1-11eb-9a0b-2b1bea95bf8d.png)

### Dark

![Screen Shot 2021-05-19 at 10 14 05 PM](https://user-images.githubusercontent.com/14828820/118909641-4fc6f480-b8f1-11eb-945b-a1762ede8ca5.png)

### Light

![Screen Shot 2021-05-19 at 10 14 25 PM](https://user-images.githubusercontent.com/14828820/118909654-55243f00-b8f1-11eb-9c5d-2f83b8d464c3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
