### PR TITLE
fix(combobox): removed unwanted shadow

### DIFF
--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -203,7 +203,7 @@ export namespace ComboBox {
           const customValue = content.getAttribute("aria-label");
           const displayCustomValue = content.getAttribute("display-value");
           if (customValue && displayCustomValue) {
-            return { [this.optionId]: customValue.replace(/\s/g, ""), [this.optionValue]: displayCustomValue };
+            return { [this.optionId]: customValue, [this.optionValue]: displayCustomValue };
           }
         }) as OptionMember[];
       }
@@ -852,7 +852,14 @@ export namespace ComboBox {
             part="combobox-options"
             role="listbox"
             aria-label=${this.label}
-            style=${styleMap({ display: this.expanded ? "block" : "none", "z-index": "1" })}
+            style=${styleMap({
+              display: this.expanded
+                ? this.options.length && this.filteredOptions.length === 0 && this.inputValue && this.allowCustomValue
+                  ? "none"
+                  : "block"
+                : "none",
+              "z-index": "1"
+            })}
           >
             ${repeat(
               this.filterOptions(this.trimSpace ? this.inputValue.replace(/\s+/g, "") : this.inputValue),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Updated the search parameter for custom Value  and removed shadow under the empty list box
## Description
<!--- Describe your changes in detail -->
1. The issue occurs whenever someone used to search for custom values with spaces in it (or say multiple words). So when user enters a values and a space it always used to give no result because what the code was doing, it was replacing the custom value and trimming all the spaces. Thus the entered value suppose "blah test" was being replaced to "blahtest" and that's why the include always failed. IT was like "blahtest".includes("blah t") instead it should have been "blah test".includes("blah t")
2. When entering custom values the user doesn't expect to see the No Result if nothing matched. But what was happening the list box used to become empty but there was a slight shadow left beneath of the empty dropdown.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira-eng-sjc12.cisco.com/jira/browse/CAX-1039

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<img width="884" alt="Screenshot 2021-05-31 at 9 56 05 AM" src="https://user-images.githubusercontent.com/30186349/120139609-6c6b0280-c1f6-11eb-80fc-0571c228d77b.png">
<img width="307" alt="Screenshot 2021-05-31 at 9 43 23 AM" src="https://user-images.githubusercontent.com/30186349/120138694-a76c3680-c1f4-11eb-8f3d-81a5eab369c2.png">

As you can see currently it is showing the result but as soon as we give space it gives No Result. 
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->
<img width="361" alt="Screenshot 2021-05-31 at 9 55 19 AM" src="https://user-images.githubusercontent.com/30186349/120139533-50676100-c1f6-11eb-90dd-a2b64e4d791e.png">
Now the combobox is able to take space also as an input

<img width="361" alt="Screenshot 2021-05-31 at 9 55 47 AM" src="https://user-images.githubusercontent.com/30186349/120139582-61b06d80-c1f6-11eb-8f18-822b805cb051.png">
the shadow has been removed from beneath

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
