### PR TITLE
disable the global *:focus styles

### DIFF
--- a/core/scss/elements/elements.scss
+++ b/core/scss/elements/elements.scss
@@ -10,6 +10,6 @@
   }
 }
 
-*:focus {
-  @include focus-styles;
-}
+// *:focus {
+//   @include focus-styles;
+// }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disable the `*:focus` styles, as they cannot be overridden or turned off like any other styles that have tag or class qualifiers.

## Related Issue
https://github.com/momentum-design/momentum-ui/issues/964

## Motivation and Context
Remove global `*:focus` from the stylesheet. At the very least it would need additional qualifiers.

## How Has This Been Tested?
I tested it in my own project, which is internal

## Screenshots:
**Before**:
<img width="308" alt="Screen Shot 2021-06-23 at 11 14 06 AM" src="https://user-images.githubusercontent.com/4137098/123132317-3c3d0b00-d414-11eb-9eca-6a8e6a3df0eb.png">

**After**:
<img width="318" alt="Screen Shot 2021-06-23 at 11 14 20 AM" src="https://user-images.githubusercontent.com/4137098/123132330-40692880-d414-11eb-9af1-bb539bec317c.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
