### PR TITLE
Remove aria attributes in button and momentum-ui/core upgrade in web-components.

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -40,7 +40,7 @@
     "lit-html": "1.2.1"
   },
   "peerDependencies": {
-    "@momentum-ui/core": "19.15.8",
+    "@momentum-ui/core": "19.15.9",
     "@momentum-ui/icons": "8.21.0",
     "@momentum-ui/tokens": "1.7.1",
     "@momentum-ui/utils": "6.2.15",
@@ -67,7 +67,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@interactjs/types": "1.10.3",
-    "@momentum-ui/core": "19.15.8",
+    "@momentum-ui/core": "19.15.9",
     "@momentum-ui/icons": "8.21.0",
     "@momentum-ui/tokens": "1.7.1",
     "@momentum-ui/utils": "6.2.15",

--- a/web-components/src/components/button/Button.ts
+++ b/web-components/src/components/button/Button.ts
@@ -282,8 +282,8 @@ export namespace Button {
             @click=${(e: MouseEvent) => this.handleClick(e)}
             @keydown=${(e: KeyboardEvent) => this.handleKeyDown(e)}
             tabindex=${this.tabIndex}
-            aria-label=${this.ariaLabel}
-            aria-labelledby=${ifDefined(this.ariaLabelledBy)}
+            aria-label=${ifDefined(this.ariaLabel || undefined)}
+            aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
             aria-expanded=${this.ariaExpanded}
             aria-haspopup=${this.ariaHaspopup}
             type=${this.type}
@@ -304,8 +304,8 @@ export namespace Button {
             role=${this.role}
             tabindex=${this.tabIndex}
             aria-pressed=${this.ariaPressed}
-            aria-label=${this.ariaLabel}
-            aria-labelledby=${this.ariaLabelledBy}
+            aria-label=${ifDefined(this.ariaLabel || undefined)}
+            aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
             type=${this.type}
             alt=${this.label}
             value=${this.value}
@@ -323,8 +323,8 @@ export namespace Button {
             role=${this.role}
             tabindex=${this.tabIndex}
             aria-pressed=${this.ariaPressed}
-            aria-label=${this.ariaLabel}
-            aria-labelledby=${this.ariaLabelledBy}
+            aria-label=${ifDefined(this.ariaLabel || undefined)}
+            aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
             href=${this.href}
           >
             ${this.childrenTemplate()}


### PR DESCRIPTION
## Description
1. Adding check for properties ariaLabel and ariaLabelledBy - if they are not provided or empty it should not render.
2. Updated `momentum-ui/core` version from  `19.15.8` to **`19.15.9`** in web-components.

## Related Issue
[CX-7012: momentum web component: Unnecessary aria attributes are added with empty string](https://jira-eng-chn-sjc3.cisco.com/jira/browse/CX-7012)

## Motivation and Context
[CX-7012: momentum web component: Unnecessary aria attributes are added with empty string](https://jira-eng-chn-sjc3.cisco.com/jira/browse/CX-7012)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
![image](https://user-images.githubusercontent.com/41057192/131676431-1d170c01-edf3-4b8d-b643-c9d41eafdab2.png)

**After**:
![image](https://user-images.githubusercontent.com/41057192/131676512-01177643-37e4-422c-9677-acefa83c97bd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
