### PR TITLE
build: update fast-glob version from 2.2.6 to 3.2.7

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -28,7 +28,7 @@
     "@gfx/zopfli": "^1.0.11",
     "@momentum-ui/tokens": "^1.7.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "fast-glob": "^2.2.6",
+    "fast-glob": "^3.2.7",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
     "handlebars": "^4.1.0",


### PR DESCRIPTION
## Description
Updating the fast-glob version from 2.2.6 to 3.2.7 because the current version has some security vulnerability

## Related Issue
There are lots of vulnerabilities listed in https://github.com/momentum-design/momentum-ui/issues/1162 but this PR is to fix only fast-glob used in momentum-ui/utils

## Motivation and Context
While running yarn audit on some project using this, it will throw a security vulnerability with Severity as high.

## How Has This Been Tested?
### **Not able to test it locally**

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
