### PR TITLE
fix: Remove input clear button, if input is readonly

### DIFF
--- a/web-components/src/components/input/Input.test.ts
+++ b/web-components/src/components/input/Input.test.ts
@@ -332,4 +332,12 @@ describe("Input Component", () => {
     const { detail } = await oneEvent(element, "input-change");
     expect(detail).toBeDefined();
   });
+
+  test("Should not show cancel button if input is readOnly",async()=>{
+    const element= await fixture<Input.ELEMENT>(
+      html`<md-input label="Multiline" containerSize="small-12" ?readonly=${true}></md-input>`
+    );
+      const rightTemplate=element.shadowRoot!.querySelector(".md-input__after")?.querySelector("md-button");
+      expect(rightTemplate).toBeNull();
+  })
 });

--- a/web-components/src/components/input/Input.ts
+++ b/web-components/src/components/input/Input.ts
@@ -424,7 +424,7 @@ export namespace Input {
     }
 
     inputRightTemplate() {
-      if (this.clear && !this.disabled && !!this.value) {
+      if (this.clear && !this.disabled && !!this.value && !this.readOnly) {
         return html`
           <div class="md-input__after">
             <md-button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
<img width="1792" alt="Screenshot 2022-04-13 at 8 30 29 PM" src="https://user-images.githubusercontent.com/43469952/163377619-f6491c0e-28a6-4525-a5fe-d3bc11118b0e.png">
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
