### PR TITLE
feat: dropdown to watch for changes in default option prop

### DIFF
--- a/web-components/src/components/dropdown/Dropdown.test.ts
+++ b/web-components/src/components/dropdown/Dropdown.test.ts
@@ -234,6 +234,25 @@ describe("Dropdown Component", () => {
     it("should render correct icon name", () => {
       expect(dropdown.shadowRoot!.querySelector("md-icon")!.getAttribute("name")).toEqual("icon-arrow-down_16");
     });
+
+    it("should change selectedKey on update of default option", async () => {
+      const dropdown = await fixture<Dropdown.ELEMENT>(
+        html`
+          <md-dropdown
+            .options="${dropdownObjectLongOptions}"
+            .defaultOption="${dropdownObjectLongOptions[10]}"
+            option-id="id"
+            option-value="country"
+          ></md-dropdown>
+        `
+      );
+      expect(dropdown["selectedKey"]).toEqual(dropdownObjectLongOptions[10].id);
+
+      dropdown["defaultOption"] = dropdownObjectLongOptions[1];
+      await elementUpdated(dropdown);
+
+      expect(dropdown["selectedKey"]).toEqual(dropdownObjectLongOptions[1].id);
+    });
   });
 
   describe("List", () => {

--- a/web-components/src/components/dropdown/Dropdown.ts
+++ b/web-components/src/components/dropdown/Dropdown.ts
@@ -104,6 +104,13 @@ export namespace Dropdown {
         if (name === "disabled") {
           this.setAttribute("tabindex", !this.disabled ? "0" : "-1");
         }
+        if (name === "defaultOption") {
+          if (this.defaultOption) {
+            const { key } = this.getOptionKeyValuePair(this.defaultOption);
+
+            this.selectedKey = key;
+          }
+        }
       });
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Dropdown component does not watch for changes in `defaultOption` prop, when this is changed programatically. This results in display of outdated selected option on UI.
This PR fixes this issue by adding a watcher for changes in `defaultOption` prop.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Discovered this issue while implementing user preferences pane in UX refresh

## How Has This Been Tested?
Tested using built bundle in consumer code. And also via unit tests

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
