### PR TITLE
trigger coutrychange event on clearing the country

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/phone-input/PhoneInput.ts
+++ b/web-components/src/components/phone-input/PhoneInput.ts
@@ -91,25 +91,24 @@ export namespace PhoneInput {
     }
 
     handleCountryChange(event: CustomEvent) {
-      if (!event.detail.value || !event.detail.value.id) {
+      if (!event.detail.value || !event.detail.value?.id) {
         this.countryCode = "US";
         this.countryCallingCode = "";
-        this.validateNumber();
-        return;
+      } else {
+        this.countryCallingCode = event.detail.value.id;
+        this.countryCode = event.detail.value.id.split(",")[2]?.trim();
       }
-      this.countryCallingCode = event.detail.value.id;
-      this.countryCode = event.detail.value.id.split(",")[2]?.trim();
       this.validateNumber();
       this.dispatchEvent(
-        new CustomEvent("countrycode-change",{
-          bubbles:true,
-          composed:true,
-          detail:{
-            srcEvent : event,
+        new CustomEvent("countrycode-change", {
+          bubbles: true,
+          composed: true,
+          detail: {
+            srcEvent: event,
             isValid: this.isValid
           }
         })
-      )
+      );
     }
 
     handlePhoneChange(event: CustomEvent) {
@@ -248,4 +247,3 @@ declare global {
     "md-phone-input": PhoneInput.ELEMENT;
   }
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On clearing countryCode trigger countryCodechange event so that can be used by listners.
No behavioural changes on the component.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
