### PR TITLE
fix: upgraded node-sass to sass

### DIFF
--- a/icons-rebrand/package.json
+++ b/icons-rebrand/package.json
@@ -60,7 +60,7 @@
     "handlebars": "^4.1.0",
     "lodash": "^4.17.11",
     "multi-glob": "^1.0.1",
-    "node-sass": "^4.11.0",
+    "sass": "^1.56.1",
     "node-watch": "^0.5.7",
     "npm-run-all": "^4.1.5",
     "npm-watch": "^0.3.0",

--- a/icons/package.json
+++ b/icons/package.json
@@ -61,7 +61,7 @@
     "handlebars": "^4.1.0",
     "lodash": "^4.17.11",
     "multi-glob": "^1.0.1",
-    "node-sass": "^4.11.0",
+    "sass": "^1.56.1",
     "node-watch": "^0.5.7",
     "npm-run-all": "^4.1.5",
     "npm-watch": "^0.3.0",

--- a/tools/icons/generators.js
+++ b/tools/icons/generators.js
@@ -1,7 +1,7 @@
 const { camelCase } = require("lodash");
 const handlebars = require("handlebars");
 const path = require("path");
-const sass = require("node-sass");
+const sass = require("sass");
 const svgson = require("svgson");
 
 const { readFile, writeFile } = require('./icons-utils');


### PR DESCRIPTION
## Description
- Upgraded node-sass to sass in icons folder to make Icons Font generation work again.


## How Has This Been Tested?
- Tested locally by running `yarn build:icons-rebrand`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

