### PR TITLE
fix: Home Page: Search- All is always present when searching for any specific entity

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/combobox/ComboBox.test.ts
+++ b/web-components/src/components/combobox/ComboBox.test.ts
@@ -466,6 +466,17 @@ describe("Combobox Component", () => {
       expect(el.input!.value).toEqual("combobox");
       expect(el.focusedIndex).toEqual(0);
       expect(el.selectedOptions.length).toEqual(1);
+      const tab = createEvent(Key.Tab);
+      el.expanded = true;
+      el.focusedIndex = 0;
+      el.input!.value = "combobox";
+      el.selectedOptions.push("Afghanistan");
+      await elementUpdated(el);
+
+      el.input!.dispatchEvent(tab);
+      expect(el.expanded).toBeFalsy();
+      expect(el.input!.value).toEqual("combobox");
+      expect(el.focusedIndex).toEqual(0);
 
       const home = createEvent(Key.Home);
 

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -727,7 +727,7 @@ export namespace ComboBox {
     handleInputKeyUp(event: KeyboardEvent) {
       switch (event.code) {
         case Key.Escape: {
-          return;
+          break;
         }
         case Key.Backspace:
           {
@@ -902,7 +902,10 @@ export namespace ComboBox {
             this.focusedIndex = -1;
           }
           break;
-        case Key.Tab:
+        case Key.Tab: {
+          this.setVisualListbox(false);
+          break;
+        }
         case Key.Enter:
           {
             this.setFocusOnHost(true);
@@ -1025,7 +1028,6 @@ export namespace ComboBox {
           break;
         }
         default: {
-          this.setVisualListbox(true);
           break;
         }
       }
@@ -1503,6 +1505,7 @@ export namespace ComboBox {
                   ? ""
                   : this.placeholder}
                 aria-controls="md-combobox-listbox"
+                ?readonly=${this.allowSelectAll}
                 ?disabled=${this.disabled}
                 ?autofocus=${this.autofocus}
                 title=${ifDefined(this.inputTitle())}

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -902,14 +902,14 @@ export namespace ComboBox {
             this.focusedIndex = -1;
           }
           break;
-        case Key.Tab: {
-          this.setVisualListbox(false);
-          break;
-        }
+        case Key.Tab:
         case Key.Enter:
           {
             this.setFocusOnHost(true);
             this.setVisualListbox(false);
+            if(event.code === Key.Tab && this.isMulti){
+              return;
+            }
             this.updateOnNextFrame(() => {
               const option = this.getFocusedItem(!this.allowSelectAll ? this.focusedIndex : this.focusedIndex - 1);
               if (this.allowCustomValue && this.input && this.input.value.length) {

--- a/web-components/src/mixins/FocusTrapMixin.test.ts
+++ b/web-components/src/mixins/FocusTrapMixin.test.ts
@@ -366,7 +366,6 @@ describe("FocusTrap Mixin", () => {
     focusTrap!["setFocusableElements"]!();
     focusTrap!["initialFocusComplete"] = true;
     document.dispatchEvent(new CustomEvent("on-widget-update"));
-    document.dispatchEvent(new CustomEvent("deactivate-focus-trap"));
 
 
     await nextFrame();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Home Page: Search- All is always present when searching for any specific entity
## Description
<!--- Describe your changes in detail -->
Searching or typing in input field is restricted in case of allow-select-all is true
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
