### PR TITLE
#CX-9804 : fix for inactivity popup on inactive screen

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.7.20",
+  "version": "2.7.21",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/modal/Modal.test.ts
+++ b/web-components/src/components/modal/Modal.test.ts
@@ -123,18 +123,22 @@ describe("Modal Component", () => {
     expect(element.show).toBeTruthy();
   });
 
-  test("should close modal when enter key is pressed", async () => {
+  test("should not close modal when enter key is pressed and focus is not on close buttons", async () => {
     jest.useFakeTimers();
-
+    element.show = true;
     await elementUpdated(element);
+    const enterPressEvent = new KeyboardEvent("keydown", { code: "Enter" });
+    element.handleKeyDown(enterPressEvent);
+    expect(element.show).toBeTruthy();
+  });
 
-    const mockEnterClick = jest.spyOn(element, "handleKeyDown");
-    element.handleKeyDown(new KeyboardEvent("Enter"));
+  test("should not close modal when enter space is pressed and focus is not on close buttons", async () => {
+    jest.useFakeTimers();
+    element.show = true;
     await elementUpdated(element);
-
-    expect(mockEnterClick).toHaveBeenCalled();
-
-    mockEnterClick.mockRestore();
+    const enterPressEvent = new KeyboardEvent("keydown", { code: "Space" });
+    element.handleKeyDown(enterPressEvent);
+    expect(element.show).toBeTruthy();
   });
 
   test("should close modal if backdrop button clicked", async () => {

--- a/web-components/src/components/modal/Modal.ts
+++ b/web-components/src/components/modal/Modal.ts
@@ -19,7 +19,6 @@ import styles from "./scss/module.scss";
 
 export const modalType = ["default", "full", "large", "small", "dialog"] as const;
 
-const fadeDuration = 150;
 const minisculeLatency = 13;
 /**
  * Increasing latency above 13 ms has an increasingly negative impact
@@ -156,12 +155,8 @@ export namespace Modal {
 
     private modalFadeOut() {
       this.animating = false;
-
       this.deactivateFocusTrap!();
-
-      setTimeout(() => {
-        this.notifyModalClose();
-      }, fadeDuration);
+      this.notifyModalClose();
     }
 
     handleCloseBackdrop() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
