### PR TITLE
fix: enhance audio player error dispatching and teardown

### DIFF
--- a/web-components/src/[sandbox]/examples/date-time-picker.ts
+++ b/web-components/src/[sandbox]/examples/date-time-picker.ts
@@ -23,7 +23,6 @@ export const dateTimePickerTemplate = html`
   <h3>date-time-picker with value</h3>
   <md-date-time-picker
     value="2021-02-14T12:00:00-08:00"
-    @date-time-change=${() => console.log("fart")}
   ></md-date-time-picker>
   <h3>disabled date-time-picker</h3>
   <md-date-time-picker value="2021-02-14T12:00:00-08:00" disabled></md-date-time-picker>

--- a/web-components/src/components/audio-player/AudioPlayer.ts
+++ b/web-components/src/components/audio-player/AudioPlayer.ts
@@ -61,6 +61,7 @@ export type Label = {
 
 export type LabelMap = {
   playBtn: Label;
+  pauseBtn: Label;
   duration: Label;
   timeline: Label;
   volumeBtn: Label;
@@ -70,8 +71,12 @@ export type LabelMap = {
 
 export const defaultLabelMap = {
   playBtn: {
-    ariaLabel: "Play / Pause",
-    tooltipText: "Play / Pause"
+    ariaLabel: "Play",
+    tooltipText: "Play"
+  },
+  pauseBtn: {
+    ariaLabel: "Pause",
+    tooltipText: "Pause"
   },
   duration: {
     ariaLabel: "Duration:",
@@ -143,6 +148,8 @@ export namespace AudioPlayer {
       super.disconnectedCallback();
       document.removeEventListener("click", this.onOutsideClick);
       document.removeEventListener("keydown", this.handleKeyDown);
+      this.audio.pause();
+      this.isPlaying = false;
     }
 
     setAudioEventListeners() {
@@ -152,12 +159,14 @@ export namespace AudioPlayer {
       };
 
       this.audio.onerror = () => {
-        this.dispatchEvent(
-          new CustomEvent("playback-error", {
-            composed: true,
-            bubbles: true
-          })
-        );
+        if (this.audio.src) {
+          this.dispatchEvent(
+            new CustomEvent("playback-error", {
+              composed: true,
+              bubbles: true
+            })
+          );
+        }
       };
 
       this.audio.onended = () => {
@@ -314,12 +323,15 @@ export namespace AudioPlayer {
         <div class="md-audio-player">
           <div class="inner-container">
             <div class="play-container">
-              <md-tooltip placement="top" message="${this.labelMap.playBtn.tooltipText}">
+              <md-tooltip
+                placement="top"
+                message="${this.isPlaying ? this.labelMap.pauseBtn.tooltipText : this.labelMap.playBtn.tooltipText}"
+              >
                 <md-button
                   hasRemoveStyle
                   class="play-btn"
                   @click="${this.togglePlay}"
-                  aria-label="${this.labelMap.playBtn.ariaLabel}"
+                  aria-label="${this.isPlaying ? this.labelMap.pauseBtn.ariaLabel : this.labelMap.playBtn.ariaLabel}"
                 >
                   ${this.isPlaying
                     ? html`


### PR DESCRIPTION
The audio player will now stop audio when the component is destroyed and the audio player will not dispatch an error when the src is an empty string

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Error handling for audio src will ignore empty strings to avoid error dispatching when component is mounted but src has  not yet been set. The component will also stop any playing audio when teardown occurs, due to no native way to destroy audio sources in browser.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
