### PR TITLE
feat: add buffering state to audio player component

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.7.36",
+  "version": "2.7.37",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/audio-player/scss/audio-player.scss
+++ b/web-components/src/components/audio-player/scss/audio-player.scss
@@ -49,6 +49,7 @@ md-button::part(button) {
   height: rem-calc(6);
   width: 100%;
   border-radius: $audio-player-timeline__border-radius;
+  position: relative;
 }
 
 .progress-bar {
@@ -57,6 +58,19 @@ md-button::part(button) {
   width: 0;
   transition: 0.25s;
   border-radius: $audio-player-timeline__border-radius;
+  position: absolute;
+  z-index: 2;
+}
+
+.buffer-bar {
+  background: var(--audio-player-background-buffer-bar, $lm-audio-player-background-buffer-bar-light);
+  height: 100%;
+  width: 0;
+  transition: 0.25s;
+  border-radius: $audio-player-timeline__border-radius;
+  position: absolute;
+  top: 0;
+  opacity: .6;
 }
 
 .text-container {

--- a/web-components/src/components/audio-player/tokens/lm-audio-player-token.js
+++ b/web-components/src/components/audio-player/tokens/lm-audio-player-token.js
@@ -14,6 +14,10 @@ const audioPlayer = {
       light: colors.gray[80].name,
       dark: colors.gray["05"].name
     },
+    "buffer-bar": {
+      light: colors.gray[40].name,
+      dark: colors.gray["30"].name
+    },
     timeline: {
       light: colors.gray[30].name,
       dark: colors.gray[60].name

--- a/web-components/src/components/audio-player/tokens/md-audio-player-token.js
+++ b/web-components/src/components/audio-player/tokens/md-audio-player-token.js
@@ -14,6 +14,10 @@ const audioPlayer = {
       light: colors.gray[80].name,
       dark: colors.gray["05"].name
     },
+    "buffer-bar": {
+      light: colors.gray[50].name,
+      dark: colors.gray["30"].name
+    },
     timeline: {
       light: colors.gray[30].name,
       dark: colors.gray[60].name


### PR DESCRIPTION
The audio player component now has a timeline indicator to show what range is buffered

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A separate gray indicator has been added to the timeline (progress bar) of the audio component to indicate which portion of it has been buffered

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira-eng-sjc12.cisco.com/jira/browse/CX-11617
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->
https://github.com/momentum-design/momentum-ui/assets/20385642/c142713e-e85b-44b1-9dc8-ac0f411b8ab8

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
