### PR TITLE
fix: 🐛 active tab color contrast issue

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.7.48",
+  "version": "2.7.49",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/tabs/tokens/lm-tabs-tokens.js
+++ b/web-components/src/components/tabs/tokens/lm-tabs-tokens.js
@@ -51,7 +51,7 @@ const tabs = {
       dark: colors.gray[70].name
     },
     active: {
-      light: colors.blue[60].name,
+      light: colors.blue[70].name,
       dark: colors.theme[50].name
     }
   },

--- a/web-components/src/components/tabs/tokens/md-tabs-tokens.js
+++ b/web-components/src/components/tabs/tokens/md-tabs-tokens.js
@@ -47,7 +47,7 @@ const tabs = {
       dark: colors.gray[60].name
     },
     active: {
-      light: colors.theme[50].name,
+      light: colors.theme[70].name,
       dark: colors.theme[40].name
     }
   },


### PR DESCRIPTION
## Description
Addressed active tab color contrast issue, changed the color code so that color contrast of at least 4:5:1 is maintained.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
