### PR TITLE
CX-10233 : Screen Readers: Resize Modal button is announced without sufficient context

### DIFF
--- a/web-components/src/components/floating-modal/FloatingModal.ts
+++ b/web-components/src/components/floating-modal/FloatingModal.ts
@@ -196,7 +196,7 @@ export namespace FloatingModal {
     handleToggleExpandCollapse(event: Event) {
       this.full = !this.full;
       this.dispatchEvent(
-        new CustomEvent("floating-modal-fullscreen", {
+        new CustomEvent("maximize-restore-event", {
           composed: true,
           bubbles: true,
           detail: {

--- a/web-components/src/components/floating-modal/FloatingModal.ts
+++ b/web-components/src/components/floating-modal/FloatingModal.ts
@@ -26,6 +26,7 @@ export namespace FloatingModal {
     @property({ type: Boolean, reflect: true, attribute: "full-screen" }) full = false;
     @property({ type: String, attribute: "close-aria-label" }) closeAriaLabel = "Close Modal";
     @property({ type: String, attribute: "resize-aria-label" }) resizeAriaLabel = "Resize Modal";
+    @property({ type: String, attribute: "maximize-aria-label" }) maximizeScreenLabel  = "Maximize modal";
     @property({ type: String, attribute: "minimize-aria-label" }) minimizeAriaLabel = "Minimize Modal";
     @property({ type: Boolean, reflect: true }) private minimize = false;
     @property({type: Object}) position: {
@@ -195,16 +196,6 @@ export namespace FloatingModal {
 
     handleToggleExpandCollapse(event: Event) {
       this.full = !this.full;
-      this.dispatchEvent(
-        new CustomEvent("maximize-restore-event", {
-          composed: true,
-          bubbles: true,
-          detail: {
-            srcEvent: event,
-            full: this.full
-          }
-        })
-      );
     }
 
     private resizeMoveListener = (event: Interact.ResizeEvent) => {
@@ -322,7 +313,7 @@ export namespace FloatingModal {
                   ${!this.minimize ? html` <md-button
                     color="color-none"
                     class="md-floating__resize"
-                    aria-label="${this.resizeAriaLabel}"
+                    aria-label="${this.full ? this.resizeAriaLabel: this.maximizeScreenLabel}"
                     circle
                     @click=${this.handleToggleExpandCollapse}
                   >

--- a/web-components/src/components/floating-modal/FloatingModal.ts
+++ b/web-components/src/components/floating-modal/FloatingModal.ts
@@ -194,7 +194,7 @@ export namespace FloatingModal {
       }
     }
 
-    handleToggleExpandCollapse(event: Event) {
+    handleToggleExpandCollapse() {
       this.full = !this.full;
     }
 

--- a/web-components/src/components/floating-modal/FloatingModal.ts
+++ b/web-components/src/components/floating-modal/FloatingModal.ts
@@ -193,8 +193,17 @@ export namespace FloatingModal {
       }
     }
 
-    handleToggleExpandCollapse() {
+    handleToggleExpandCollapse(event: Event) {
       this.full = !this.full;
+      this.dispatchEvent(
+        new CustomEvent("floating-modal-fullscreen", {
+          composed: true,
+          bubbles: true,
+          detail: {
+            srcEvent: event
+          }
+        })
+      );
     }
 
     private resizeMoveListener = (event: Interact.ResizeEvent) => {
@@ -312,7 +321,7 @@ export namespace FloatingModal {
                   ${!this.minimize ? html` <md-button
                     color="color-none"
                     class="md-floating__resize"
-                    aria-label="${this.full ? 'Fullscreen Resize Modal' : 'Halfscreen Resize Modal'}"
+                    aria-label="${this.resizeAriaLabel}"
                     circle
                     @click=${this.handleToggleExpandCollapse}
                   >

--- a/web-components/src/components/floating-modal/FloatingModal.ts
+++ b/web-components/src/components/floating-modal/FloatingModal.ts
@@ -200,7 +200,8 @@ export namespace FloatingModal {
           composed: true,
           bubbles: true,
           detail: {
-            srcEvent: event
+            srcEvent: event,
+            full: this.full
           }
         })
       );

--- a/web-components/src/components/floating-modal/FloatingModal.ts
+++ b/web-components/src/components/floating-modal/FloatingModal.ts
@@ -26,7 +26,7 @@ export namespace FloatingModal {
     @property({ type: Boolean, reflect: true, attribute: "full-screen" }) full = false;
     @property({ type: String, attribute: "close-aria-label" }) closeAriaLabel = "Close Modal";
     @property({ type: String, attribute: "resize-aria-label" }) resizeAriaLabel = "Resize Modal";
-    @property({ type: String, attribute: "maximize-aria-label" }) maximizeScreenLabel  = "Maximize modal";
+    @property({ type: String, attribute: "maximize-aria-label" }) maximizeScreenLabel  = "Maximize Modal";
     @property({ type: String, attribute: "minimize-aria-label" }) minimizeAriaLabel = "Minimize Modal";
     @property({ type: Boolean, reflect: true }) private minimize = false;
     @property({type: Object}) position: {

--- a/web-components/src/components/floating-modal/FloatingModal.ts
+++ b/web-components/src/components/floating-modal/FloatingModal.ts
@@ -312,7 +312,7 @@ export namespace FloatingModal {
                   ${!this.minimize ? html` <md-button
                     color="color-none"
                     class="md-floating__resize"
-                    aria-label="${this.resizeAriaLabel}"
+                    aria-label="${this.full ? 'Fullscreen Resize Modal' : 'Halfscreen Resize Modal'}"
                     circle
                     @click=${this.handleToggleExpandCollapse}
                   >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Story - CX-10233
Prerequisites:

1. Tab to reach the Webex button and press enter to activate it.
2. Tab to reach the resize modal button and observe the announcement when it is full-screen mode and half-screen mode.
**Expected Result:**
The resize Modal button should be announced with sufficient context i.e. When the model is in halfscreen mode, it should announce as 'Halfscreen Resize Modal' and when the model is in fullscreen mode, it should announce as 'Fullscreen Resize Modal' or similar.
**Actual Result:**
The 'Resize Modal' button is announced without sufficient context. i.e.
- the 'Resize Modal' button announces the same label for both the half-screen and full-screen mode and the screen reader user will not know the state of the control as 'Resize Modal, button'

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
fix(accessibility): implement dynamic label for 'Resize Modal'

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Issue screenshot - 
![image](https://github.com/momentum-design/momentum-ui/assets/51110665/97021b47-ed2e-4d83-852a-fa307b283fce)
 
 Video Link For Issue - https://platform.applause.com/services/links/v1/external/e418790303d083cd604a5701204ac017906e12812bec60a519e8b183979279e9
 
 Screenshot after Fix - 
 
<img width="1792" alt="image" src="https://github.com/momentum-design/momentum-ui/assets/51110665/f3e0d320-9ee7-475f-9afe-1a7bc1f69b6d">

<img width="1792" alt="image" src="https://github.com/momentum-design/momentum-ui/assets/51110665/b1596377-b166-4dea-8378-ddb6692afe11">


VidCast Link - https://app.vidcast.io/share/d5f69e35-c744-4a5b-9c72-f25d5f7fb263