### PR TITLE
Accessibility fix: [CX-13319] updated role for menu overlay component 

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.7.55",
+  "version": "2.7.56",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.7.56",
+  "version": "2.7.55",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -401,7 +401,7 @@ export namespace MenuOverlay {
         ${this.getStyles()}
         <div aria-expanded=${this.isOpen} class="md-menu-overlay">
           <slot name="menu-trigger"></slot>
-          <div part="overlay" class="overlay-container" role="tooltip">
+          <div part="overlay" class="overlay-container" role="menu">
             <div id="arrow" class="overlay-arrow" data-popper-arrow></div>
             <div class="overlay-content" part="overlay-content">
               <slot></slot>


### PR DESCRIPTION
Accessibility fix for menu-overlay component 

## Description
Updated the role type to "menu" from "tooltip" for the menu overlay component

## Related Issue
https://jira-eng-sjc12.cisco.com/jira/browse/CX-13319

## Motivation and Context
Referred : https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
[ARIA: menu role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role)
The menu role is a type of composite widget that offers a list of choices to the user.

Screen Recording of before and after fix:
https://github.com/momentum-design/momentum-ui/assets/41052645/7c7eeec1-aab1-45b0-89df-e71b0bd97ad0
