### PR TITLE
#feat: added arai label and role property for link component

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/[sandbox]/examples/link.ts
+++ b/web-components/src/[sandbox]/examples/link.ts
@@ -48,4 +48,9 @@ export const linkTemplate = html`
       tab-index -1
     </md-link>
   </div>
+  <div class="row">
+    <md-link ariaLabel="Test Link">
+      Link with Aria Label
+    </md-link>
+  </div>
 `;

--- a/web-components/src/[sandbox]/examples/link.ts
+++ b/web-components/src/[sandbox]/examples/link.ts
@@ -53,4 +53,9 @@ export const linkTemplate = html`
       Link with Aria Label
     </md-link>
   </div>
+  <div class="row">
+    <md-link role="button">
+      Role as button
+    </md-link>
+  </div>
 `;

--- a/web-components/src/components/link/Link.stories.ts
+++ b/web-components/src/components/link/Link.stories.ts
@@ -10,7 +10,7 @@ import { withA11y } from "@storybook/addon-a11y";
 import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
 import { html } from "lit-element";
 import "@/components/link/Link";
-import { linkTag, linkColor } from "./Link"; // Keep type import as a relative path
+import { linkTag, linkColor, linkRole } from "./Link"; // Keep type import as a relative path
 import "@/components/theme/Theme";
 
 export default {
@@ -34,12 +34,14 @@ export const Link = () => {
   const target = text("Target", "_self");
   const color = select("Link color", linkColor, "blue");
   const ariaLabel = text("AriaLabel", "Link Storybook");
+  const role = select("Link Role", linkRole, "");
 
   return html`
     <md-theme class="theme-toggle" id="link" ?darkTheme=${darkTheme} ?lumos=${lumos}>
       <md-link
         .href=${href}
         .ariaLabel=${ariaLabel}
+        .role=${role}
         .tag=${tag as any}
         .target="${target}"
         .color="${color}"

--- a/web-components/src/components/link/Link.stories.ts
+++ b/web-components/src/components/link/Link.stories.ts
@@ -32,16 +32,18 @@ export const Link = () => {
   const disabled = boolean("Disabled", false);
   const inline = boolean("Link Inline", false);
   const target = text("Target", "_self");
-  const color = select("Link color", linkColor, "blue")
+  const color = select("Link color", linkColor, "blue");
+  const ariaLabel = text("AriaLabel", "Link Storybook");
 
   return html`
     <md-theme class="theme-toggle" id="link" ?darkTheme=${darkTheme} ?lumos=${lumos}>
-      <md-link 
-        .href=${href} 
-        .tag=${tag as any} 
+      <md-link
+        .href=${href}
+        .ariaLabel=${ariaLabel}
+        .tag=${tag as any}
         .target="${target}"
         .color="${color}"
-        ?disabled=${disabled} 
+        ?disabled=${disabled}
         ?inline=${inline}>Default Link</md-link>
     </md-theme>
   `;

--- a/web-components/src/components/link/Link.test.ts
+++ b/web-components/src/components/link/Link.test.ts
@@ -35,6 +35,21 @@ describe("Link component", () => {
     expect(component.className).toContain("md-link--yellow");
   });
 
+  // role
+  test("should set role when passed", async () => {
+    expect.hasAssertions();
+    const component: Link.ELEMENT = await fixture(` <md-link role="button"></md-link> `);
+    expect(component.role).toContain("button");
+  });
+
+  // role
+  test("should set role as link when not passed", async () => {
+    expect.hasAssertions();
+    const component: Link.ELEMENT = await fixture(` <md-link></md-link> `);
+    expect(component.role).toContain("link");
+  });
+
+
   test("should render correct aria label", async () => {
     expect.hasAssertions();
     const component: Link.ELEMENT = await fixture(`<md-link ariaLabel="Link Component"></md-link>`);

--- a/web-components/src/components/link/Link.test.ts
+++ b/web-components/src/components/link/Link.test.ts
@@ -35,6 +35,20 @@ describe("Link component", () => {
     expect(component.className).toContain("md-link--yellow");
   });
 
+  test("should render correct aria label", async () => {
+    expect.hasAssertions();
+    const component: Link.ELEMENT = await fixture(`<md-link ariaLabel="Link Component"></md-link>`);
+    const linkComponent = component.shadowRoot?.querySelector("a");
+    expect(linkComponent?.getAttribute("aria-label")).toMatch("Link Component");
+  });
+
+  test("should not set aria label when not passed", async () => {
+    expect.hasAssertions();
+    const component: Link.ELEMENT = await fixture(`<md-link class="md-link--yellow"></md-link>`);
+    const linkComponent = component.shadowRoot?.querySelector("a");
+    expect(linkComponent?.getAttribute("aria-label")).toBeNull();
+  });
+
   test("should set link tab-index", async () => {
     expect.hasAssertions();
     const component: Link.ELEMENT = await fixture(` <md-link tab-index="1"></md-link> `);

--- a/web-components/src/components/link/Link.ts
+++ b/web-components/src/components/link/Link.ts
@@ -15,15 +15,18 @@ import styles from "./scss/module.scss";
 
 export const linkTag = ["a", "div", "span"] as const;
 export const linkColor = ["", "blue", "red", "green", "yellow", "orange"] as const;
+export const linkRole = ["link", "button"] as const;
 
 export namespace Link {
   export type Tag = typeof linkTag[number];
   export type Color = typeof linkColor[number];
+  export type Role = typeof linkRole[number];
 
   @customElementWithCheck("md-link")
   export class ELEMENT extends LitElement {
     @property({ type: String, attribute: false }) color: Color = "";
     @property({ type: String }) ariaLabel = "";
+    @property({ type: String }) role: Role = "link";
     @property({ type: Boolean }) disabled = false;
     @property({ type: Boolean }) inline = false;
     @property({ type: String }) href = "";
@@ -58,13 +61,13 @@ export namespace Link {
         switch (this.tag) {
           case "div":
             return html`
-              <div class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex} role="link" part="link">
+              <div class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.role} part="link">
                 <slot></slot>
               </div>
             `;
           case "span":
             return html`
-              <span class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex} role="link" part="link">
+              <span class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.role} part="link">
                 <slot></slot>
               </span>
             `;
@@ -73,11 +76,11 @@ export namespace Link {
             return html`
               <a
                 class="md-link ${classMap(linkClassNamesInfo)}"
-                aria-label=${ifDefined(this.ariaLabel || undefined)}
                 .target="${this.target}"
                 href=${this.href}
                 tabindex=${this.tabIndex}
-                role="link"
+                aria-label=${ifDefined(this.ariaLabel || undefined)}
+                role=${this.role}
                 part="link"
               >
                 <slot></slot>

--- a/web-components/src/components/link/Link.ts
+++ b/web-components/src/components/link/Link.ts
@@ -10,6 +10,7 @@ import reset from "@/wc_scss/reset.scss";
 import { customElementWithCheck } from "@/mixins/CustomElementCheck";
 import { html, LitElement, property } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
+import { ifDefined } from "lit-html/directives/if-defined";
 import styles from "./scss/module.scss";
 
 export const linkTag = ["a", "div", "span"] as const;
@@ -22,6 +23,7 @@ export namespace Link {
   @customElementWithCheck("md-link")
   export class ELEMENT extends LitElement {
     @property({ type: String, attribute: false }) color: Color = "";
+    @property({ type: String }) ariaLabel = "";
     @property({ type: Boolean }) disabled = false;
     @property({ type: Boolean }) inline = false;
     @property({ type: String }) href = "";
@@ -71,6 +73,7 @@ export namespace Link {
             return html`
               <a
                 class="md-link ${classMap(linkClassNamesInfo)}"
+                aria-label=${ifDefined(this.ariaLabel || undefined)}
                 .target="${this.target}"
                 href=${this.href}
                 tabindex=${this.tabIndex}


### PR DESCRIPTION
## Description
Added aria label and role property for md-link component

## Related Issue
Story: https://jira-eng-sjc12.cisco.com/jira/browse/CX-10268

## Motivation and Context
1) md-link only reads the text and does not provide any aria label if more description is required
2) Some places the role needs to be button, hence added new property to accept role

## How Has This Been Tested?
1) Tested using Mac VoiceOver
2) Tested using JAWS
3) Added UTs 
4) Tested story book

## Screenshots:
**After**:
![Screenshot 2024-02-27 at 11 56 01 AM](https://github.com/momentum-design/momentum-ui/assets/41052645/33d0d8ef-180b-449b-b458-fcda20a3ea04)

![Screenshot 2024-02-27 at 11 22 27 AM](https://github.com/momentum-design/momentum-ui/assets/41052645/f2c1597f-7064-450b-8d45-73a967ff2351)

Video
https://app.vidcast.io/share/4bcaef25-8e93-4be7-a252-7b16a9a072c3

Coverage
![Screenshot 2024-02-27 at 11 37 47 AM](https://github.com/momentum-design/momentum-ui/assets/41052645/bde42296-9d0a-4e24-9064-d6c98da53f5e)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
