### PR TITLE
#CX-10275: fix(accessibility)Profile: Screen reader: User agent profile dialog is not implemented or announced as such

### DIFF
--- a/web-components/src/[sandbox]/examples/menu-overlay.ts
+++ b/web-components/src/[sandbox]/examples/menu-overlay.ts
@@ -529,5 +529,23 @@ export const menuOverlayTemplate = html`
         </md-tooltip>
       </div>
   </md-menu-overlay>
+
+  <h3 class="sandbox-header" style="margin: .5rem 1rem">Menu with role as dialog and aria label</h3>
+  <div>
+  <md-menu-overlay ariaRole="dialog" ariaLabel="sample label">
+    <md-button slot="menu-trigger" variant="primary">Open Menu Overlay </md-button>
+    <div style="padding:1.25rem ; width: 100%;">
+      <md-input htmlId="inputSearchClearPill" containerSize="small-12" placeholder="Enter Text" shape="pill" clear>
+      </md-input>
+      <md-checkbox>Default Checkbox</md-checkbox>
+      <md-checkbox checked>Default Checked Checkbox</md-checkbox>
+      <md-checkbox indeterminate>Default Indeterminate Checkbox</md-checkbox>
+      <div style="text-align: center">
+        <p style="margin-bottom: .5rem">Please complete the entire form</p>
+        <md-button variant="primary">Submit</md-button>
+      </div>
+    </div>
+  </md-menu-overlay>
+</div>
   </div>
 `;

--- a/web-components/src/components/menu-overlay/MenuOverlay.stories.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.stories.ts
@@ -15,7 +15,7 @@ import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
 import { html } from "lit-element";
 import "@/components/menu-overlay/MenuOverlay";
-import { menuOverlayPlacement, menuOverlaySize } from "./MenuOverlay"; // Keep type import as a relative path
+import { menuOverlayPlacement, menuOverlaySize, menuOverlayRole } from "./MenuOverlay"; // Keep type import as a relative path
 
 export default {
   title: "Components/Menu Overlay",
@@ -46,6 +46,9 @@ export const MenuOverlay = () => {
   const size = select("size", menuOverlaySize, "large");
   const maxHeight = text("max height", "");
   const customWidth = text("custom width", "");
+  const ariaRole = select("ariaRole", menuOverlayRole, "menu");
+  const ariaLabel = text("AriaLabel", "Link Storybook");
+
 
   return html`
     <md-theme class="theme-toggle" id="menu-overlay" ?darkTheme=${darkTheme} ?lumos=${lumos}>
@@ -55,6 +58,8 @@ export const MenuOverlay = () => {
         size=${size}
         max-height=${maxHeight}
         custom-width=${customWidth}
+        ariaRole=${ariaRole}
+        ariaLabel=${ariaLabel}
         ?is-open=${isOpen}
         ?show-arrow=${showArrow}
         ?disabled=${disabled}

--- a/web-components/src/components/menu-overlay/MenuOverlay.test.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.test.ts
@@ -442,12 +442,18 @@ describe("MenuOverlay", () => {
     const component: MenuOverlay.ELEMENT = await fixture(`<md-menu-overlay ariaRole="dialog" ></md-menu-overlay>`);
     const overlayPart = component.shadowRoot?.querySelector('div[part="overlay"]');
     expect(overlayPart?.getAttribute('role')).toEqual("dialog");
+    // when the role is dialog, aria-modal should be true
+    expect(overlayPart?.getAttribute('aria-modal')).toEqual("true");
+
   });
 
   test("should have a role as menu when we are not passing", async () => {
     const component: MenuOverlay.ELEMENT = await fixture(`<md-menu-overlay ></md-menu-overlay>`);
     const overlayPart = component.shadowRoot?.querySelector('div[part="overlay"]');
     expect(overlayPart?.getAttribute('role')).toEqual("menu");
+    // when the role is other than dialog, aria-modal should be false
+    expect(overlayPart?.hasAttribute('aria-modal')).toBe(false);
+
   });
 
 

--- a/web-components/src/components/menu-overlay/MenuOverlay.test.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.test.ts
@@ -425,4 +425,30 @@ describe("MenuOverlay", () => {
     expect(element.isOpen).toBeTruthy();
     expect(document.activeElement).not.toEqual(button);
   });
+
+  test("should have an aria-label attribute when ariaLabel is set", async () => {
+    const component: MenuOverlay.ELEMENT = await fixture(`<md-menu-overlay ariaLabel="Menu Overlay"></md-menu-overlay>`);
+    const overlayPart = component.shadowRoot?.querySelector('div[part="overlay"]');
+    expect(overlayPart?.getAttribute('aria-label')).toEqual('Menu Overlay');
+  });
+
+  test("should not have an aria-label attribute when ariaLabel is not set", async () => {
+    const component: MenuOverlay.ELEMENT = await fixture(`<md-menu-overlay ></md-menu-overlay>`);
+    const overlayPart = component.shadowRoot?.querySelector('div[part="overlay"]');
+    expect(overlayPart?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test("should have a role when we set ariaRole", async () => {
+    const component: MenuOverlay.ELEMENT = await fixture(`<md-menu-overlay ariaRole="dialog" ></md-menu-overlay>`);
+    const overlayPart = component.shadowRoot?.querySelector('div[part="overlay"]');
+    expect(overlayPart?.getAttribute('role')).toEqual("dialog");
+  });
+
+  test("should have a role as menu when we are not passing", async () => {
+    const component: MenuOverlay.ELEMENT = await fixture(`<md-menu-overlay ></md-menu-overlay>`);
+    const overlayPart = component.shadowRoot?.querySelector('div[part="overlay"]');
+    expect(overlayPart?.getAttribute('role')).toEqual("menu");
+  });
+
+
 });

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -78,6 +78,7 @@ export namespace MenuOverlay {
     @property({ type: Boolean }) disabled = false;
     @property({ type: String }) placement: MenuOverlay.Placement = "bottom";
     @property({ type: Boolean, attribute: "allow-hover-toggle" }) allowHoverToggle = false;
+    @property({ type: String, attribute: "custom-role" }) customRole = "menu";
 
     @query(".overlay-container") overlayContainer!: HTMLDivElement;
     @query(".overlay-arrow") arrow!: HTMLDivElement;
@@ -401,7 +402,7 @@ export namespace MenuOverlay {
         ${this.getStyles()}
         <div aria-expanded=${this.isOpen} class="md-menu-overlay">
           <slot name="menu-trigger"></slot>
-          <div part="overlay" class="overlay-container" role="menu">
+          <div part="overlay" class="overlay-container" role=${this.customRole} ${this.customRole == 'dialog' ? 'aria-modal="true"' : ''}>
             <div id="arrow" class="overlay-arrow" data-popper-arrow></div>
             <div class="overlay-content" part="overlay-content">
               <slot></slot>

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -82,7 +82,8 @@ export namespace MenuOverlay {
     @property({ type: Boolean }) disabled = false;
     @property({ type: String }) placement: MenuOverlay.Placement = "bottom";
     @property({ type: Boolean, attribute: "allow-hover-toggle" }) allowHoverToggle = false;
-    @property({ type: String, attribute: "custom-role" }) customRole: Role = "menu";
+    @property({ type: String }) ariaRole: Role = "menu";
+    @property({ type: String }) ariaLabel = "";
 
 
     @query(".overlay-container") overlayContainer!: HTMLDivElement;
@@ -407,8 +408,9 @@ export namespace MenuOverlay {
         ${this.getStyles()}
         <div aria-expanded=${this.isOpen} class="md-menu-overlay">
           <slot name="menu-trigger"></slot>
-          <div part="overlay" class="overlay-container" role=${this.customRole} 
-          aria-modal=${ifDefined(this.customRole === 'dialog' ? "true" : undefined)}
+          <div part="overlay" class="overlay-container" role=${this.ariaRole} 
+          aria-modal=${ifDefined(this.ariaRole === 'dialog' ? "true" : undefined)}
+          aria-label=${ifDefined(this.ariaLabel || undefined)}
           >
             <div id="arrow" class="overlay-arrow" data-popper-arrow></div>
             <div class="overlay-content" part="overlay-content">

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -83,7 +83,7 @@ export namespace MenuOverlay {
     @property({ type: String }) placement: MenuOverlay.Placement = "bottom";
     @property({ type: Boolean, attribute: "allow-hover-toggle" }) allowHoverToggle = false;
     @property({ type: String }) ariaRole: Role = "menu";
-    @property({ type: String }) ariaLabel = "";
+    @property({ type: String }) ariaLabel: string = "";
 
 
     @query(".overlay-container") overlayContainer!: HTMLDivElement;

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -396,7 +396,7 @@ export namespace MenuOverlay {
     static get styles() {
       return [styles];
     }
-//test commit
+
     render() {
       return html`
         ${this.getStyles()}

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -410,7 +410,7 @@ export namespace MenuOverlay {
           <slot name="menu-trigger"></slot>
           <div part="overlay" class="overlay-container" role=${this.ariaRole} 
           aria-modal=${ifDefined(this.ariaRole === 'dialog' ? "true" : undefined)}
-          aria-label=${ifDefined(this.ariaLabel || undefined)}
+          aria-label=${ifDefined(this.ariaLabel)}
           >
             <div id="arrow" class="overlay-arrow" data-popper-arrow></div>
             <div class="overlay-content" part="overlay-content">

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -50,10 +50,13 @@ export const menuOverlayPlacement = [
   "bottom",
   "bottom-end"
 ] as const;
+export const menuOverlayRole = ["menu", "dialog"] as const;
+
 
 export namespace MenuOverlay {
   export type Size = typeof menuOverlaySize[number];
   export type Placement = typeof menuOverlayPlacement[number];
+  export type Role = typeof menuOverlayRole[number];
 
   @customElementWithCheck("md-menu-overlay")
   export class ELEMENT extends FocusTrapMixin(LitElement) {
@@ -79,7 +82,8 @@ export namespace MenuOverlay {
     @property({ type: Boolean }) disabled = false;
     @property({ type: String }) placement: MenuOverlay.Placement = "bottom";
     @property({ type: Boolean, attribute: "allow-hover-toggle" }) allowHoverToggle = false;
-    @property({ type: String, attribute: "custom-role" }) customRole = "menu";
+    @property({ type: String, attribute: "custom-role" }) customRole: Role = "menu";
+
 
     @query(".overlay-container") overlayContainer!: HTMLDivElement;
     @query(".overlay-arrow") arrow!: HTMLDivElement;
@@ -403,7 +407,7 @@ export namespace MenuOverlay {
         ${this.getStyles()}
         <div aria-expanded=${this.isOpen} class="md-menu-overlay">
           <slot name="menu-trigger"></slot>
-          <div part="overlay" class="overlay-container" role="${this.customRole}" 
+          <div part="overlay" class="overlay-container" role=${this.customRole} 
           aria-modal=${ifDefined(this.customRole === 'dialog' ? "true" : undefined)}
           >
             <div id="arrow" class="overlay-arrow" data-popper-arrow></div>

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -410,7 +410,7 @@ export namespace MenuOverlay {
           <slot name="menu-trigger"></slot>
           <div part="overlay" class="overlay-container" role=${this.ariaRole} 
           aria-modal=${ifDefined(this.ariaRole === 'dialog' ? "true" : undefined)}
-          aria-label=${ifDefined(this.ariaLabel)}
+          aria-label=${ifDefined(this.ariaLabel || undefined)}
           >
             <div id="arrow" class="overlay-arrow" data-popper-arrow></div>
             <div class="overlay-content" part="overlay-content">

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -395,7 +395,7 @@ export namespace MenuOverlay {
     static get styles() {
       return [styles];
     }
-
+//test commit
     render() {
       return html`
         ${this.getStyles()}

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -18,6 +18,7 @@ import preventOverflow from "@popperjs/core/lib/modifiers/preventOverflow";
 import { createPopper, defaultModifiers, Instance, Rect } from "@popperjs/core/lib/popper-lite";
 import { html, LitElement, property, PropertyValues, query, queryAssignedNodes } from "lit-element";
 import styles from "./scss/module.scss";
+import { ifDefined } from "lit-html/directives/if-defined";
 
 export enum OverlaySizes {
   small = "260px",
@@ -402,7 +403,9 @@ export namespace MenuOverlay {
         ${this.getStyles()}
         <div aria-expanded=${this.isOpen} class="md-menu-overlay">
           <slot name="menu-trigger"></slot>
-          <div part="overlay" class="overlay-container" role=${this.customRole} ${this.customRole == 'dialog' ? 'aria-modal="true"' : ''}>
+          <div part="overlay" class="overlay-container" role="${this.customRole}" 
+          aria-modal=${ifDefined(this.customRole === 'dialog' ? "true" : undefined)}
+          >
             <div id="arrow" class="overlay-arrow" data-popper-arrow></div>
             <div class="overlay-content" part="overlay-content">
               <slot></slot>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CX-10275

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
![image](https://github.com/momentum-design/momentum-ui/assets/79409177/75fa1191-67b3-4d8e-863e-9f95a5655861)

<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
