### PR TITLE
feat: Renamed role to ariaRole property

### DIFF
--- a/web-components/src/[sandbox]/examples/link.ts
+++ b/web-components/src/[sandbox]/examples/link.ts
@@ -54,7 +54,7 @@ export const linkTemplate = html`
     </md-link>
   </div>
   <div class="row">
-    <md-link role="button">
+    <md-link custom-role="button">
       Role as button
     </md-link>
   </div>

--- a/web-components/src/[sandbox]/examples/link.ts
+++ b/web-components/src/[sandbox]/examples/link.ts
@@ -54,7 +54,7 @@ export const linkTemplate = html`
     </md-link>
   </div>
   <div class="row">
-    <md-link custom-role="button">
+    <md-link ariaRole="button">
       Role as button
     </md-link>
   </div>

--- a/web-components/src/components/link/Link.stories.ts
+++ b/web-components/src/components/link/Link.stories.ts
@@ -41,7 +41,7 @@ export const Link = () => {
       <md-link
         .href=${href}
         .ariaLabel=${ariaLabel}
-        .custom-role=${role}
+        .ariaRole=${role}
         .tag=${tag as any}
         .target="${target}"
         .color="${color}"

--- a/web-components/src/components/link/Link.stories.ts
+++ b/web-components/src/components/link/Link.stories.ts
@@ -41,7 +41,7 @@ export const Link = () => {
       <md-link
         .href=${href}
         .ariaLabel=${ariaLabel}
-        .role=${role}
+        .custom-role=${role}
         .tag=${tag as any}
         .target="${target}"
         .color="${color}"

--- a/web-components/src/components/link/Link.test.ts
+++ b/web-components/src/components/link/Link.test.ts
@@ -38,7 +38,7 @@ describe("Link component", () => {
   // role
   test("should set role when passed", async () => {
     expect.hasAssertions();
-    const component: Link.ELEMENT = await fixture(` <md-link custom-role="button"></md-link> `);
+    const component: Link.ELEMENT = await fixture(` <md-link ariaRole="button"></md-link> `);
     const linkComponent = component.shadowRoot?.querySelector("a");
     expect(linkComponent?.getAttribute("role")).toContain("button");
   });

--- a/web-components/src/components/link/Link.test.ts
+++ b/web-components/src/components/link/Link.test.ts
@@ -38,17 +38,18 @@ describe("Link component", () => {
   // role
   test("should set role when passed", async () => {
     expect.hasAssertions();
-    const component: Link.ELEMENT = await fixture(` <md-link role="button"></md-link> `);
-    expect(component.role).toContain("button");
+    const component: Link.ELEMENT = await fixture(` <md-link custom-role="button"></md-link> `);
+    const linkComponent = component.shadowRoot?.querySelector("a");
+    expect(linkComponent?.getAttribute("role")).toContain("button");
   });
 
   // role
   test("should set role as link when not passed", async () => {
     expect.hasAssertions();
     const component: Link.ELEMENT = await fixture(` <md-link></md-link> `);
-    expect(component.role).toContain("link");
+    const linkComponent = component.shadowRoot?.querySelector("a");
+    expect(linkComponent?.getAttribute("role")).toContain("link");
   });
-
 
   test("should render correct aria label", async () => {
     expect.hasAssertions();

--- a/web-components/src/components/link/Link.ts
+++ b/web-components/src/components/link/Link.ts
@@ -15,7 +15,18 @@ import styles from "./scss/module.scss";
 
 export const linkTag = ["a", "div", "span"] as const;
 export const linkColor = ["", "blue", "red", "green", "yellow", "orange"] as const;
-export const linkRole = ["link", "button"] as const;
+export const linkRole = [
+  "button",
+  "checkbox",
+  "link",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "radio",
+  "switch",
+  "tab"
+] as const;
 
 export namespace Link {
   export type Tag = typeof linkTag[number];
@@ -26,7 +37,7 @@ export namespace Link {
   export class ELEMENT extends LitElement {
     @property({ type: String, attribute: false }) color: Color = "";
     @property({ type: String }) ariaLabel = "";
-    @property({ type: String }) role: Role = "link";
+    @property({ type: String, attribute: "custom-role" }) customRole: Role = "link";
     @property({ type: Boolean }) disabled = false;
     @property({ type: Boolean }) inline = false;
     @property({ type: String }) href = "";
@@ -61,13 +72,13 @@ export namespace Link {
         switch (this.tag) {
           case "div":
             return html`
-              <div class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.role} part="link">
+              <div class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.customRole} part="link">
                 <slot></slot>
               </div>
             `;
           case "span":
             return html`
-              <span class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.role} part="link">
+              <span class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.customRole} part="link">
                 <slot></slot>
               </span>
             `;
@@ -80,7 +91,7 @@ export namespace Link {
                 href=${this.href}
                 tabindex=${this.tabIndex}
                 aria-label=${ifDefined(this.ariaLabel || undefined)}
-                role=${this.role}
+                role=${this.customRole}
                 part="link"
               >
                 <slot></slot>

--- a/web-components/src/components/link/Link.ts
+++ b/web-components/src/components/link/Link.ts
@@ -37,7 +37,7 @@ export namespace Link {
   export class ELEMENT extends LitElement {
     @property({ type: String, attribute: false }) color: Color = "";
     @property({ type: String }) ariaLabel = "";
-    @property({ type: String, attribute: "custom-role" }) customRole: Role = "link";
+    @property({ type: String }) ariaRole: Role = "link";
     @property({ type: Boolean }) disabled = false;
     @property({ type: Boolean }) inline = false;
     @property({ type: String }) href = "";
@@ -72,13 +72,13 @@ export namespace Link {
         switch (this.tag) {
           case "div":
             return html`
-              <div class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.customRole} part="link">
+              <div class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.ariaRole} part="link">
                 <slot></slot>
               </div>
             `;
           case "span":
             return html`
-              <span class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.customRole} part="link">
+              <span class="md-link ${classMap(linkClassNamesInfo)}" tabindex=${this.tabIndex}  aria-label=${ifDefined(this.ariaLabel || undefined)} role=${this.ariaRole} part="link">
                 <slot></slot>
               </span>
             `;
@@ -91,7 +91,7 @@ export namespace Link {
                 href=${this.href}
                 tabindex=${this.tabIndex}
                 aria-label=${ifDefined(this.ariaLabel || undefined)}
-                role=${this.customRole}
+                role=${this.ariaRole}
                 part="link"
               >
                 <slot></slot>


### PR DESCRIPTION
## Description
Renamed role to ariaRole attribute to avoid conflict of attribute names

## Related Issue
https://github.com/momentum-design/momentum-ui/pull/1551

## Motivation and Context
In react based component, the property can not be passed with dot notaion. To avoid the conflict, renamed the role to ariaRole

## How Has This Been Tested?
1. Updated UTs
2. Updated story book
3. JAWs will read out twice if the role is in parent and child both, hence fixed by renaming it to ariaRole.

## Screenshots:
**Before** (If applicable):
![308059913-33d0d8ef-180b-449b-b458-fcda20a3ea04](https://github.com/momentum-design/momentum-ui/assets/41052645/16049015-1cc7-4da3-a4e4-57d0b837332a)

**After**:
![Screenshot 2024-03-04 at 5 09 23 PM](https://github.com/momentum-design/momentum-ui/assets/41052645/61debb22-d6ba-4213-a852-b3df8ab56c1f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
