### PR TITLE
fix(cx-10429) : Meaningful icons focused but not announced 

### DIFF
--- a/web-components/src/components/badge/Badge.ts
+++ b/web-components/src/components/badge/Badge.ts
@@ -75,9 +75,9 @@ export namespace Badge {
 
       const splitContent = () => {
         return html`
-          <slot aria-hidden="true" name="split-left" class="split split-left"></slot>
+          <slot name="split-left" class="split split-left"></slot>
           <span aria-hidden="true" class="split-separator"> | </span>
-          <slot aria-hidden="true" name="split-right" class="split split-right"></slot>
+          <slot name="split-right" class="split split-right"></slot>
         `;
       };
 

--- a/web-components/src/components/badge/Badge.ts
+++ b/web-components/src/components/badge/Badge.ts
@@ -12,6 +12,7 @@ import { html, LitElement, property } from "lit-element";
 import { nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import styles from "./scss/module.scss";
+import { ifDefined } from "lit-html/directives/if-defined";
 
 export namespace Badge {
   @customElementWithCheck("md-badge")
@@ -29,6 +30,7 @@ export namespace Badge {
     @property({ type: Boolean }) split = false;
     @property({ type: Boolean }) disabled = false;
     @property({ type: String }) tabIndexing = "";
+    @property({ type: String }) ariaHiddenSplits = "";
 
     renderBgColor = () => {
       return this.bgColor ? `background-color: ${this.bgColor};` : nothing;
@@ -75,9 +77,9 @@ export namespace Badge {
 
       const splitContent = () => {
         return html`
-          <slot name="split-left" class="split split-left"></slot>
+          <slot aria-hidden=${ifDefined(this.ariaHiddenSplits || undefined)} name="split-left" class="split split-left"></slot>
           <span aria-hidden="true" class="split-separator"> | </span>
-          <slot name="split-right" class="split split-right"></slot>
+          <slot aria-hidden=${ifDefined(this.ariaHiddenSplits || undefined)} name="split-right" class="split split-right"></slot>
         `;
       };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
