### PR TITLE
fix(cx 10437) : Outdial Call: Screen Readers: Combobox expand/collapse button focused separately

### DIFF
--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -1354,6 +1354,7 @@ export namespace ComboBox {
           aria-expanded=${this.expanded}
           aria-controls="md-combobox-listbox"
           tabindex="-1"
+          aria-hidden="true"
           ?disabled=${this.disabled}
           @click=${this.toggleVisualListBox}
         >
@@ -1368,9 +1369,9 @@ export namespace ComboBox {
         <button
           type="button"
           class="md-combobox-button"
-          aria-label=${this.arrowAriaLabel}
           aria-controls="md-combobox-listbox"
           tabindex="-1"
+          aria-hidden="true"
           ?disabled=${this.disabled}
           @click=${(e: MouseEvent) => this.toggleGroupListBox(e, data)}
         >

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -1350,7 +1350,6 @@ export namespace ComboBox {
         <button
           type="button"
           class="md-combobox-button arrow-down"
-          aria-label=${this.arrowAriaLabel}
           aria-expanded=${this.expanded}
           aria-controls="md-combobox-listbox"
           tabindex="-1"

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -82,7 +82,7 @@ export namespace ComboBox {
     @property({ type: Boolean, attribute: "show-custom-error", reflect: true }) showCustomError = false;
     @property({ type: Boolean, attribute: "show-loader", reflect: true }) showLoader = false;
     @property({ type: Boolean, attribute: "show-selected-count", reflect: true }) showSelectedCount = false;
-    @property({ type: String, attribute: "popup-indicator-aria-hidden" }) popupIndicatorAriaHidden = "true";
+    @property({ type: String, attribute: "popup-chevron-aria-hidden" }) popupChevronAriaHidden = "true";
 
     @property({ type: Number, attribute: false })
     @internalProperty()
@@ -1352,10 +1352,10 @@ export namespace ComboBox {
           type="button"
           class="md-combobox-button arrow-down"
           aria-expanded=${this.expanded}
-          aria-label=${ifDefined(this.popupIndicatorAriaHidden === "true" ? undefined : this.arrowAriaLabel)}
+          aria-label=${ifDefined(this.popupChevronAriaHidden === "true" ? undefined : this.arrowAriaLabel)}
           aria-controls="md-combobox-listbox"
           tabindex="-1"
-          aria-hidden=${this.popupIndicatorAriaHidden}
+          aria-hidden=${this.popupChevronAriaHidden}
           ?disabled=${this.disabled}
           @click=${this.toggleVisualListBox}
         >
@@ -1370,10 +1370,10 @@ export namespace ComboBox {
         <button
           type="button"
           class="md-combobox-button"
-          aria-label=${ifDefined(this.popupIndicatorAriaHidden === "true" ? undefined : this.arrowAriaLabel)}
+          aria-label=${ifDefined(this.popupChevronAriaHidden === "true" ? undefined : this.arrowAriaLabel)}
           aria-controls="md-combobox-listbox"
           tabindex="-1"
-          aria-hidden=${this.popupIndicatorAriaHidden}
+          aria-hidden=${this.popupChevronAriaHidden}
           ?disabled=${this.disabled}
           @click=${(e: MouseEvent) => this.toggleGroupListBox(e, data)}
         >

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -82,6 +82,7 @@ export namespace ComboBox {
     @property({ type: Boolean, attribute: "show-custom-error", reflect: true }) showCustomError = false;
     @property({ type: Boolean, attribute: "show-loader", reflect: true }) showLoader = false;
     @property({ type: Boolean, attribute: "show-selected-count", reflect: true }) showSelectedCount = false;
+    @property({ type: String, attribute: "popup-indicator-aria-hidden" }) popupIndicatorAriaHidden = "true";
 
     @property({ type: Number, attribute: false })
     @internalProperty()
@@ -1351,9 +1352,10 @@ export namespace ComboBox {
           type="button"
           class="md-combobox-button arrow-down"
           aria-expanded=${this.expanded}
+          aria-label=${ifDefined(this.popupIndicatorAriaHidden === "true" ? undefined : this.arrowAriaLabel)}
           aria-controls="md-combobox-listbox"
           tabindex="-1"
-          aria-hidden="true"
+          aria-hidden=${this.popupIndicatorAriaHidden}
           ?disabled=${this.disabled}
           @click=${this.toggleVisualListBox}
         >
@@ -1368,9 +1370,10 @@ export namespace ComboBox {
         <button
           type="button"
           class="md-combobox-button"
+          aria-label=${ifDefined(this.popupIndicatorAriaHidden === "true" ? undefined : this.arrowAriaLabel)}
           aria-controls="md-combobox-listbox"
           tabindex="-1"
-          aria-hidden="true"
+          aria-hidden=${this.popupIndicatorAriaHidden}
           ?disabled=${this.disabled}
           @click=${(e: MouseEvent) => this.toggleGroupListBox(e, data)}
         >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CX-10437

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
