### PR TITLE
CAUI-8826 - Fix a11y for default tab selection

### DIFF
--- a/web-components/src/components/tabs/Tab.ts
+++ b/web-components/src/components/tabs/Tab.ts
@@ -153,7 +153,7 @@ export namespace Tab {
 
     connectedCallback() {
       super.connectedCallback();
-      this.setAttribute("aria-selected", `${this._selected}`);
+      this.setAttribute("aria-selected", `${this.selected}`);
     }
 
     protected firstUpdated(changedProperties: PropertyValues) {

--- a/web-components/src/components/tabs/Tab.ts
+++ b/web-components/src/components/tabs/Tab.ts
@@ -153,7 +153,7 @@ export namespace Tab {
 
     connectedCallback() {
       super.connectedCallback();
-      this.setAttribute("aria-selected", "false");
+      this.setAttribute("aria-selected", `${this._selected}`);
     }
 
     protected firstUpdated(changedProperties: PropertyValues) {


### PR DESCRIPTION
## Description
When tabs are initialised, the `aria-selected` attribute is set false even for the selected tab. This causes screen reader to wrongly announce 'select' on the selected tab. This PR corrects the aria-label by using `selected` property

Root cause: On initial mount, `connectedCallback` is called after `set` function for `_selected` property. Hence even if the `_selected` property is set correctly, `aria-selected` gets set to false incorrectly

## Related Issue


## Motivation and Context
Fix a11y issues

## How Has This Been Tested?
Ran voiceover on MAC and JAWS on windows

## Screenshots:
**Before** (If applicable):
<img width="1316" alt="Screenshot 2024-03-14 at 4 06 24 PM" src="https://github.com/momentum-design/momentum-ui/assets/20185422/63624f5c-3808-4088-b351-4db5038287f9">

**After**:
<img width="1128" alt="Screenshot 2024-03-14 at 4 05 19 PM" src="https://github.com/momentum-design/momentum-ui/assets/20185422/8f4a0c5b-4cf7-4ee1-8656-fbecdc15799c">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
