### PR TITLE
fix: added id for modal header

### DIFF
--- a/web-components/src/components/modal/Modal.ts
+++ b/web-components/src/components/modal/Modal.ts
@@ -201,7 +201,7 @@ export namespace Modal {
             </div>
           `
         : html`
-            <div part="modal-header" class="md-modal__header">
+            <div id="modal_header" part="modal-header" class="md-modal__header">
               <h2 class="md-modal__title">${this.headerLabel}</h2>
               ${this.headerMessage
                 ? html`


### PR DESCRIPTION
## Description
Added id for modal header

## Related Issue
[CX-10496](https://jira-eng-sjc12.cisco.com/jira/browse/CX-10496): Transfer Request dialog is announced with incorrect label 

## Motivation and Context
By adding id field, the aria-labelledby will be used to announce the dialogue header

## How Has This Been Tested?
1. Tested in Jaws, announcing the header on open
2. Mac Voice Over - known issue of dialogue not announcing the header

## Screenshots:
**Before**:
Refer the jira for video

**After**:
https://app.vidcast.io/share/e7dd4b3d-4c1b-4a0c-9751-29446cc791e3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
