### PR TITLE
fix(cx-10583): remove unwanted attributes from element

### DIFF
--- a/web-components/src/components/button/Button.test.ts
+++ b/web-components/src/components/button/Button.test.ts
@@ -204,4 +204,26 @@ describe("Button Component", () => {
     const buttonElement = await fixture(`<md-button label="Button Component" tag="p"></md-button>`);
     expect(buttonElement.shadowRoot!.querySelector("button")).toBeNull();
   });
+
+  test("should render link if passed tag a with custom tabIndex of 1", async () => {
+    const element: Button.ELEMENT = await fixture(
+      html`
+        <md-button tag="a" tab-index="1"><span slot="text">Test</span></md-button>
+      `
+    );
+    const link = element.shadowRoot!.querySelector("a");
+    expect(link!.getAttribute("tabindex")).toContain("1");
+    expect(link).toBeDefined;
+  });
+
+  test("should render link if passed tag input with custom tabIndex of 1", async () => {
+    const element: Button.ELEMENT = await fixture(
+      html`
+        <md-button tag="input" tab-index="1"><span slot="text">Test</span></md-button>
+      `
+    );
+    const input = element.shadowRoot!.querySelector("input");
+    expect(input!.getAttribute("tabindex")).toContain("1");
+    expect(input).toBeDefined;
+  });
 });

--- a/web-components/src/components/button/Button.ts
+++ b/web-components/src/components/button/Button.ts
@@ -280,7 +280,7 @@ export namespace Button {
             class="md-button ${classMap(this.buttonClassMap)}"
             @click=${(e: MouseEvent) => this.handleClick(e)}
             @keydown=${(e: KeyboardEvent) => this.handleKeyDown(e)}
-            tabindex=${this.tabIndex}
+            tabindex=${ifDefined(this.tabIndex || undefined)}
             aria-label=${ifDefined(this.ariaLabel || undefined)}
             aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
             aria-expanded="${this.ariaExpanded
@@ -291,7 +291,7 @@ export namespace Button {
             aria-haspopup=${ifDefined(this.ariaHaspopup === "false" ? undefined : this.ariaHaspopup)}
             aria-pressed=${ifDefined(this.ariaPressed === "false" ? undefined : this.ariaPressed)}
             type=${this.type}
-            role=${this.role}
+            role=${ifDefined(this.role === 'button'? undefined : this.role)}
             ?disabled=${this.disabled || this.loading}
           >
             ${this.childrenTemplate()}
@@ -306,7 +306,7 @@ export namespace Button {
             @click=${(e: MouseEvent) => this.handleClick(e)}
             @keydown=${(e: KeyboardEvent) => this.handleKeyDown(e)}
             role=${this.role}
-            tabindex=${this.tabIndex}
+            tabindex=${ifDefined(this.tabIndex || undefined)}
             aria-pressed=${this.ariaPressed === 'true' ? true : false}
             aria-label=${ifDefined(this.ariaLabel || undefined)}
             aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
@@ -325,7 +325,7 @@ export namespace Button {
             @click=${(e: MouseEvent) => this.handleClick(e)}
             @keydown=${(e: KeyboardEvent) => this.handleKeyDown(e)}
             role=${this.role}
-            tabindex=${this.tabIndex}
+            tabindex=${ifDefined(this.tabIndex || undefined)}
             aria-pressed=${this.ariaPressed === 'true' ? true : false}
             aria-label=${ifDefined(this.ariaLabel || undefined)}
             aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}


### PR DESCRIPTION
As buttons, input and anchor already have tabindex of 0 and are by default included in keyboard tab navigation so removing explicit tabindex=0 from them and for buttons we are removing explicit attribute of role=button

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
