### PR TITLE
fix(CX-13612) : added ariaLive prop in button

### DIFF
--- a/web-components/src/[sandbox]/examples/button.ts
+++ b/web-components/src/[sandbox]/examples/button.ts
@@ -211,4 +211,9 @@ export const buttonTemplate = html`
       ><md-icon slot="icon" name="pause_16"></md-icon><span slot="text">Icon Button Armageddon</span></md-button
     >
   </div>
+
+  <div class="row" style="display: flex; margin: .5rem 0">
+    <h3 class="sandbox-header" style="margin: .5rem 1rem">Button with Aria Live</h3>
+    <md-button ariaLive="assertive" type="button">button</md-button>
+  </div>
 `;

--- a/web-components/src/components/button/Button.test.ts
+++ b/web-components/src/components/button/Button.test.ts
@@ -96,10 +96,32 @@ describe("Button Component", () => {
     expect(btn?.getAttribute("aria-live")).toMatch("polite");
   });
 
-  test("should not set aria live when not passed", async () => {
+  test("should not set aria live when not passed for button tag", async () => {
     const element: Button.ELEMENT = await fixture(
       html`
         <md-button></md-button>
+      `
+    );
+    const btn = element.shadowRoot!.querySelector(".md-button");
+    expect(btn?.getAttribute("aria-live")).toBeNull();
+  });
+
+
+  test("should not set aria live when not passed for input tag", async () => {
+    const element: Button.ELEMENT = await fixture(
+      html`
+        <md-button tag="input"><span slot="text">Test</span></md-button>
+      `
+    );
+    const btn = element.shadowRoot!.querySelector(".md-button");
+    expect(btn?.getAttribute("aria-live")).toBeNull();
+  });
+
+
+  test("should not set aria live when not passed for a tag", async () => {
+    const element: Button.ELEMENT = await fixture(
+      html`
+        <md-button tag="a"><span slot="text">Test</span></md-button>
       `
     );
     const btn = element.shadowRoot!.querySelector(".md-button");
@@ -167,7 +189,7 @@ describe("Button Component", () => {
     expect(element.disabled).toEqual(true);
   });
 
-  test("should set width successfulyl", async () => {
+  test("should set width successfully", async () => {
     const customWidth = "260px";
     const element: Button.ELEMENT = await fixture(
       html`
@@ -181,7 +203,7 @@ describe("Button Component", () => {
     expect(hasStyle).toBeTruthy();
   });
 
-  test("should set maxWidth successfulyl", async () => {
+  test("should set maxWidth successfully", async () => {
     const customMaxWidth = "100px";
     const element: Button.ELEMENT = await fixture(
       html`

--- a/web-components/src/components/button/Button.test.ts
+++ b/web-components/src/components/button/Button.test.ts
@@ -86,6 +86,26 @@ describe("Button Component", () => {
     expect(element.shadowRoot!.querySelectorAll(".md-button__label").length).toEqual(1);
   });
 
+  test("should render correct aria live", async () => {
+    const element: Button.ELEMENT = await fixture(
+      html`
+        <md-button ariaLive="polite" active></md-button>
+      `
+    );
+    const btn = element.shadowRoot!.querySelector(".md-button");
+    expect(btn?.getAttribute("aria-live")).toMatch("polite");
+  });
+
+  test("should not set aria live when not passed", async () => {
+    const element: Button.ELEMENT = await fixture(
+      html`
+        <md-button></md-button>
+      `
+    );
+    const btn = element.shadowRoot!.querySelector(".md-button");
+    expect(btn?.getAttribute("aria-live")).toBeNull();
+  });
+
   test("should render wrapped button in large container if label and containerLarge passed", async () => {
     const element: Button.ELEMENT = await fixture(
       html`

--- a/web-components/src/components/button/Button.ts
+++ b/web-components/src/components/button/Button.ts
@@ -75,6 +75,12 @@ export const buttonColor = [
   "color-none",
   ""
 ] as const;
+export const buttonAriaLive = [
+  "",
+  "off",
+  "polite",
+  "assertive"
+] as const;
 
 export namespace Button {
   export type Tag = typeof buttonTag[number];
@@ -82,6 +88,7 @@ export namespace Button {
   export type Role = typeof buttonRoles[number];
   export type variant = typeof buttonVariant[number];
   export type color = typeof buttonColor[number];
+  export type ariaLive = typeof buttonAriaLive[number];
   export type Attributes = {
     id?: string;
     disabled: boolean;
@@ -90,6 +97,7 @@ export namespace Button {
     type: Type;
     ariaLabel?: string;
     ariaLabelledBy?: string;
+    ariaLive?: string;
     ariaExpanded?: boolean;
     ariaHaspopup?: boolean;
     ariaPressed?: String;
@@ -130,6 +138,7 @@ export namespace Button {
 
     @property({ type: String }) ariaLabel = "";
     @property({ type: String }) ariaLabelledBy = "";
+    @property({ type: String }) ariaLive: Button.ariaLive = "";
     @property({ type: String }) ariaExpanded = "";
     @property({ type: String }) ariaHaspopup = "false";
     @property({ type: String }) ariaPressed = "false";
@@ -283,6 +292,7 @@ export namespace Button {
             tabindex=${this.tabIndex}
             aria-label=${ifDefined(this.ariaLabel || undefined)}
             aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
+            aria-live=${ifDefined(this.ariaLive || undefined)}
             aria-expanded="${this.ariaExpanded
               ? this.ariaExpanded === "true"
                 ? true
@@ -310,6 +320,7 @@ export namespace Button {
             aria-pressed=${this.ariaPressed === 'true' ? true : false}
             aria-label=${ifDefined(this.ariaLabel || undefined)}
             aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
+            aria-live=${ifDefined(this.ariaLive || undefined)}
             type=${this.type}
             alt=${this.label}
             value=${this.value}
@@ -329,6 +340,7 @@ export namespace Button {
             aria-pressed=${this.ariaPressed === 'true' ? true : false}
             aria-label=${ifDefined(this.ariaLabel || undefined)}
             aria-labelledby=${ifDefined(this.ariaLabelledBy || undefined)}
+            aria-live=${ifDefined(this.ariaLive || undefined)}
             href=${this.href}
           >
             ${this.childrenTemplate()}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added new prop ariaLive in button, the prop will be rendered only if passed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
aria-live is used by Assistive technologies to announce dynamic changes in the content.

## How Has This Been Tested?
1) Added UTs
2) Added sandbox example

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
When ariaLive is passed:

<img width="1297" alt="Screenshot 2024-03-27 at 6 18 00 PM" src="https://github.com/momentum-design/momentum-ui/assets/41052645/4313413a-d04a-46d4-8f2c-65f0babc96be">

When ariaLive is not passed:
<img width="1403" alt="Screenshot 2024-03-27 at 6 17 48 PM" src="https://github.com/momentum-design/momentum-ui/assets/41052645/d7c6e979-31bc-4cf7-b7f8-97b72a2d2d8b">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
