### PR TITLE
fix(cx-13374): Global: Keyboard Navigation: Role select menu does not follow the expected kb navigation pattern

### DIFF
--- a/web-components/src/components/dropdown/Dropdown.ts
+++ b/web-components/src/components/dropdown/Dropdown.ts
@@ -13,6 +13,7 @@ import reset from "@/wc_scss/reset.scss";
 import { internalProperty, LitElement, property, PropertyValues, query, queryAll } from "lit-element";
 import { html } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
+import { ifDefined } from "lit-html/directives/if-defined";
 import { repeat } from "lit-html/directives/repeat.js";
 import styles from "./scss/module.scss";
 
@@ -474,7 +475,7 @@ export namespace Dropdown {
             aria-label="${this.labelTitle}"
             aria-hidden="${!this.expanded}"
             part="dropdown-options"
-            tabindex=${this.customTabIndex}
+            tabindex=${ifDefined(this.customTabIndex === -1 ? undefined : this.customTabIndex)}
           >
             ${repeat(
               this.renderOptions,
@@ -483,7 +484,7 @@ export namespace Dropdown {
                 <li
                   class="md-dropdown-option"
                   role="option"
-                  tabindex=${this.customTabIndex}
+                  tabindex=${ifDefined(this.customTabIndex === -1 ? undefined : this.customTabIndex)}
                   aria-label="${o.value}"
                   label="${o.value}"
                   aria-selected="${idx === this.focusedIndex}"

--- a/web-components/src/components/dropdown/Dropdown.ts
+++ b/web-components/src/components/dropdown/Dropdown.ts
@@ -195,6 +195,11 @@ export namespace Dropdown {
     protected handleFocusOut(event: Event) {
       super.handleFocusOut && super.handleFocusOut(event);
 
+
+      if (this.expanded) {
+        this.collapse();
+      }
+
       this.dispatchEvent(
         new CustomEvent<EventDetail["dropdown-focus-out"]>("dropdown-focus-out", {
           composed: true,
@@ -272,6 +277,8 @@ export namespace Dropdown {
 
     onKeyDown = (e: KeyboardEvent) => {
       switch (e.code) {
+
+        case Key.Space:
         case Key.Enter: {
           if (!this.expanded) {
             this.expand();

--- a/web-components/src/components/input/Input.ts
+++ b/web-components/src/components/input/Input.ts
@@ -398,7 +398,7 @@ export namespace Input {
               id=${this.htmlId}
               role=${this.role}
               placeholder=${this.placeholder}
-              ?readonly=${this.readOnly}
+              ?readonly=${this.readOnly || this.disabled}
               min=${ifDefined(this.min)}
               max=${ifDefined(this.max)}
               maxlength=${ifDefined(this.maxLength)}

--- a/web-components/src/components/menu-overlay/MenuOverlay.test.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.test.ts
@@ -501,7 +501,7 @@ describe("MenuOverlay", () => {
 
     await nextFrame();
     expect(element.isOpen).toBeFalsy();
-    expect(document.activeElement).toEqual(button);
+    expect(document.activeElement).toBe(null)
   });
 
   test("shouldn't focus on trigger when press any button except escape to close modal", async () => {

--- a/web-components/src/wc_scss/tools/mixins/input.scss
+++ b/web-components/src/wc_scss/tools/mixins/input.scss
@@ -54,7 +54,7 @@
     &.md-disabled {
       background-color: $background-color-disabled;
       border-color: $input__border-color--read-only;
-      color: $color-disabled;
+      color: $color-disabled !important;
 
       &::placeholder {
         color: $color-disabled;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
cx-13374
1. Open the dropdown using space key.
2. When tab key is presses the dropdown closes and focus moves to next focusable element
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
