### PR TITLE
CX-14789 : Removed role and aria labels for disabled fields

### DIFF
--- a/web-components/src/components/editable-textfield/EditableTextfield.test.ts
+++ b/web-components/src/components/editable-textfield/EditableTextfield.test.ts
@@ -229,4 +229,18 @@ describe("Editable Textfield component", () => {
     expect(component.shadowRoot!.querySelector(".md-editable-textfield--error")).not.toBeNull;
     expect(component.shadowRoot!.querySelector(".md-editable-textfield")?.getAttribute("aria-invalid")).toEqual("true");
   });
+  test("should render role and other aria fields", async () => {
+    const component: EditableTextfield.ELEMENT = await fixture(` <md-editable-field ariaLabel="test field" aria-described-by="test Described details"></md-editable-field> `);
+    const editComponent =  component?.shadowRoot?.querySelector("div");
+    expect(editComponent?.getAttribute("role")).toContain("textbox");
+    expect(editComponent?.getAttribute("aria-label")).toMatch("test field");
+    expect(editComponent?.getAttribute("aria-describedby")).toMatch("test Described details");
+  });
+  test("should not render role and aria fields when disabled", async () => {
+    const component: EditableTextfield.ELEMENT = await fixture(` <md-editable-field disabled ariaLabel="test field" aria-described-by="test Described details"></md-editable-field> `);
+    const editComponent =  component?.shadowRoot?.querySelector("div");
+    expect(editComponent?.getAttribute("role")).toBeNull();
+    expect(editComponent?.getAttribute("aria-label")).toBeNull();
+    expect(editComponent?.getAttribute("aria-describedby")).toBeNull();
+  });
 });

--- a/web-components/src/components/editable-textfield/EditableTextfield.ts
+++ b/web-components/src/components/editable-textfield/EditableTextfield.ts
@@ -232,7 +232,7 @@ export namespace EditableTextfield {
         <div
           style="${this.overflowStyles}"
           class="md-editable-textfield ${classMap(classes)}"
-          role="textbox"
+          role=${ifDefined(!this.disabled ? "textbox" : undefined)}
           tabindex=${this.disabled ? "-1" : "0"}
           ?contenteditable=${this.isEditing}
           @focus=${this.handleFocus}
@@ -240,9 +240,9 @@ export namespace EditableTextfield {
           @keydown=${(e: KeyboardEvent) => {
             this.handleKeydown(e);
           }}
-          aria-invalid=${this.alert ? "true" : "false"}
-          aria-label=${this.ariaLabel}
-          aria-describedby=${this.ariaDescribedBy}
+          aria-invalid=${ifDefined(!this.disabled ? this.alert ? "true" : "false" : undefined)}
+          aria-label=${ifDefined(!this.disabled ? this.ariaLabel : undefined)}
+          aria-describedby=${ifDefined(!this.disabled ? this.ariaDescribedBy : undefined)}
         >
           ${dompurify.sanitize(this.content)}
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CX-14789

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
