### PR TITLE
#CX-10208 : Global: Chrome + JAWS: Incorrect heading structure in the notifications dialog

### DIFF
--- a/web-components/src/components/alert/Alert.ts
+++ b/web-components/src/components/alert/Alert.ts
@@ -92,10 +92,10 @@ export namespace Alert {
                   ${this.renderIconTemplate()}
                 </div>
                 <div part="content" class="md-alert__content">
-                  <div aria-label=${this.title} class="md-alert__title" aria-level="1">
+                  <div class="md-alert__title" aria-level="1">
                     ${this.title}
                   </div>
-                  <div aria-label=${this.message} class="md-alert__message">
+                  <div class="md-alert__message">
                     ${this.message}
                     <slot name="alert-body"></slot>
                   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removing aria-label since the content and aria-label is same, when without aria-label content will get announced by SR

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
