### PR TITLE
#CX-10573 : Focus does not move to clear input button properly

### DIFF
--- a/web-components/src/components/input/Input.ts
+++ b/web-components/src/components/input/Input.ts
@@ -293,6 +293,16 @@ export namespace Input {
         event.preventDefault();
       }
       this.input.focus();
+      this.dispatchEvent(
+        new CustomEvent("input-clear", {
+          bubbles: true,
+          composed: true,
+          detail: {
+            srcEvent: event
+          }
+        })
+      );
+      document.dispatchEvent(new CustomEvent('on-widget-update')); 
       this.handleChange(event);
     }
 

--- a/web-components/src/mixins/FocusTrapMixin.test.ts
+++ b/web-components/src/mixins/FocusTrapMixin.test.ts
@@ -125,6 +125,28 @@ describe("FocusTrap Mixin", () => {
 
   });
 
+  test("should decrease trap index when input-clear event is dispatched", async () => {
+    const focusTrap = el.shadowRoot!.querySelector<FocusTrap>("focus-trap");
+    const focusableChild = focusTrap!.querySelector<FocusableChild>("focusable-child");
+    const input = focusableChild!.shadowRoot!.querySelector("input");
+  
+    focusTrap!["activateFocusTrap"]!();
+    focusTrap!["setFocusableElements"]!();
+    await nextFrame();
+    await elementUpdated(el);
+    focusTrap!["focusTrapIndex"] = 5;
+    input!.dispatchEvent(new CustomEvent("input-clear", {
+      bubbles: true,
+      composed: true,
+      detail: {
+        srcEvent: new KeyboardEvent("keydown", { code: "Enter" })
+      }
+    }));
+    await nextFrame();
+    await elementUpdated(el);
+    expect(focusTrap!["focusTrapIndex"]).toEqual(4);
+  });
+
   test("should set trap index of element with shadowRoot", async () => {
     const focusTrap = el.shadowRoot!.querySelector<FocusTrap>("focus-trap");
     const focusableChild = focusTrap!.querySelector<FocusableChild>("focusable-child");

--- a/web-components/src/mixins/FocusTrapMixin.ts
+++ b/web-components/src/mixins/FocusTrapMixin.ts
@@ -448,7 +448,7 @@ export const FocusTrapMixin = <T extends AnyConstructor<FocusClass & FocusTrapCl
       this.removeEventListener("on-focus-untrap", this.handleChildFocusUntrap as EventListener);
       document.removeEventListener("click", this.handleOutsideTrapClick);
       document.removeEventListener("on-widget-update", this.updateFocusableElements);
-      this.addEventListener("input-clear", this.handleFocusOnClear);
+      this.removeEventListener("input-clear", this.handleFocusOnClear);
       if (this.focusableTimer) {
         clearTimeout(this.focusableTimer);
       }

--- a/web-components/src/mixins/FocusTrapMixin.ts
+++ b/web-components/src/mixins/FocusTrapMixin.ts
@@ -251,6 +251,10 @@ export const FocusTrapMixin = <T extends AnyConstructor<FocusClass & FocusTrapCl
       }
     }
 
+    handleFocusOnClear = () => {
+      this.focusTrap(true);
+    }
+
     private hasAutofocus(element: HTMLElement) {
       return element.hasAttribute("autofocus");
     }
@@ -433,6 +437,7 @@ export const FocusTrapMixin = <T extends AnyConstructor<FocusClass & FocusTrapCl
       this.addEventListener("on-focus-untrap", this.handleChildFocusUntrap as EventListener);
       document.addEventListener("click", this.handleOutsideTrapClick);
       document.addEventListener("on-widget-update", this.updateFocusableElements);
+      this.addEventListener("input-clear", this.handleFocusOnClear);
     }
 
     disconnectedCallback() {
@@ -443,6 +448,7 @@ export const FocusTrapMixin = <T extends AnyConstructor<FocusClass & FocusTrapCl
       this.removeEventListener("on-focus-untrap", this.handleChildFocusUntrap as EventListener);
       document.removeEventListener("click", this.handleOutsideTrapClick);
       document.removeEventListener("on-widget-update", this.updateFocusableElements);
+      this.addEventListener("input-clear", this.handleFocusOnClear);
       if (this.focusableTimer) {
         clearTimeout(this.focusableTimer);
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
