### PR TITLE
fix: localise DatePickerDay tooltip

### DIFF
--- a/web-components/src/components/datepicker/datepicker-day/DatePickerDay.ts
+++ b/web-components/src/components/datepicker/datepicker-day/DatePickerDay.ts
@@ -132,7 +132,7 @@ export namespace DatePickerDay {
     }
 
     render() {
-      const localisedDateFormat = localizeDate(this.day, this.datePickerProps?.locale || "en").toFormat("D, dd MMMM yyyy")
+      const localisedDateFormat = localizeDate(this.day, this.datePickerProps?.locale || "en").toFormat("D, dd MMMM yyyy");
       return html`
         <md-button
           circle

--- a/web-components/src/components/datepicker/datepicker-day/DatePickerDay.ts
+++ b/web-components/src/components/datepicker/datepicker-day/DatePickerDay.ts
@@ -9,7 +9,7 @@
 import "@/components/button/Button";
 import { DateRangePicker } from "../../date-range-picker/DateRangePicker"; // Keep type import as a relative path
 import { customElementWithCheck } from "@/mixins/CustomElementCheck";
-import { getDate, isDayDisabled, isSameDay, now } from "@/utils/dateUtils";
+import { getDate, isDayDisabled, isSameDay, now, localizeDate } from "@/utils/dateUtils";
 import { DatePickerProps, DayFilters } from "../../../utils/dateUtils"; // Keep type import as a relative path
 import { closestElement } from "@/utils/helpers";
 import reset from "@/wc_scss/reset.scss";
@@ -132,6 +132,7 @@ export namespace DatePickerDay {
     }
 
     render() {
+      const localisedDateFormat = localizeDate(this.day, this.datePickerProps?.locale || "en").toFormat("D, dd MMMM yyyy")
       return html`
         <md-button
           circle
@@ -145,8 +146,8 @@ export namespace DatePickerDay {
             }
           }}
           @keydown=${(e: KeyboardEvent) => this.handleKeyDown(e)}
-          ariaLabel=${`${this.day?.toFormat("D, dd MMMM yyyy")}`}
-          title=${`${this.day?.toFormat("D, dd MMMM yyyy")}`}
+          ariaLabel=${`${localisedDateFormat}`}
+          title=${`${localisedDateFormat}`}
           aria-selected=${ifDefined(this.selected)}
           tab-index=${this.focused ? "0" : "-1"}
         >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The tooltips for the days in the `DatePickerDay` were not localised, and were always showing as english, regardless of the specified locale. This change fixes this so that the tooltip always reflects the browser locale.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->
<img width="272" alt="image" src="https://github.com/momentum-design/momentum-ui/assets/173685639/0e7b02bf-2769-4c00-b768-7d0ca67d6633">


**After**:
<!--- Please add after images, gifs or videos here: -->
<img width="278" alt="image" src="https://github.com/momentum-design/momentum-ui/assets/173685639/7736f5af-68c0-41a5-9271-bdf17ce301ef">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
