### PR TITLE
fix(icon): accept empty var

### DIFF
--- a/web-components/src/components/avatar/Presence.test.ts
+++ b/web-components/src/components/avatar/Presence.test.ts
@@ -112,7 +112,7 @@ describe("Presence", () => {
   test("returns correct values for meeting presenceType", () => {
     const result = getPresenceIconColor("busy", false);
     expect(result).toEqual({
-      presenceIcon: "busy-presence",
+      presenceIcon: "unread-badge_12", // busy-presence
       presenceColor: "var(--avatar-presence-rona)",
       isCircularWrapper: true
     });

--- a/web-components/src/components/avatar/Presence.utils.ts
+++ b/web-components/src/components/avatar/Presence.utils.ts
@@ -60,7 +60,7 @@ export const getPresenceIconColor = (presenceType: string, failureBadge: boolean
         presenceColor = "var(--avatar-presence-inactive)";
         break;
       case "busy":
-        presenceIcon = "busy-presence";
+        presenceIcon = "unread-badge_12"; // busy-presence
         presenceColor = "var(--avatar-presence-rona)";
         break;
       case "on-mobile":

--- a/web-components/src/components/icon/Icon.ts
+++ b/web-components/src/components/icon/Icon.ts
@@ -120,7 +120,9 @@ export namespace Icon {
       if (this.sizeOverrided) {
         return `${iconName.split("_")[0]}_${this.iconFontSize}`;
       }
-      return iconNames.includes(iconName) ? `icon-${iconName}` : this.consoleHandler("name-error", iconName);
+      return iconNames.includes(iconName) || iconName === ""
+        ? `icon-${iconName}`
+        : this.consoleHandler("name-error", iconName);
     }
 
     get iconStyleMap() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Icon will show errors when there is an empty var icon name. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
