### PR TITLE
fix(highcontrast): selected tab in highlight

### DIFF
--- a/web-components/src/components/tabs/scss/tab.scss
+++ b/web-components/src/components/tabs/scss/tab.scss
@@ -179,9 +179,10 @@ button {
   }
 
   :host([selected]) button {
-    box-shadow: inset 0 -3px 0 0 Highlight;
     border-radius: $tab-focus-border-radius $tab-focus-border-radius 0 0;
-    color: Highlight;
+    color: ButtonFace;
+    background-color: Highlight !important;
+    forced-color-adjust: none;
 
     &:active {
       border-radius: $tab-focus-border-radius;

--- a/web-components/src/components/tabs/scss/tab.scss
+++ b/web-components/src/components/tabs/scss/tab.scss
@@ -180,7 +180,7 @@ button {
 
   :host([selected]) button {
     border-radius: $tab-focus-border-radius $tab-focus-border-radius 0 0;
-    color: ButtonFace;
+    color: HighlightText;
     background-color: Highlight !important;
     forced-color-adjust: none;
 
@@ -206,10 +206,12 @@ button {
       outline-offset: -1px;
     }
   }
+
   button:focus:not(:disabled) {
     outline: 1px solid Highlight;
     outline-offset: -1px;
   }
+
   button:disabled {
     forced-color-adjust: none;
     background-color: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
High Contrast: The selected tab is not visually differentiated from non-selected ones

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
![Screenshot 2024-07-30 at 10 35 00](https://github.com/user-attachments/assets/daaae1e2-1434-444c-9844-1c3711e965c4)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
