### PR TITLE
style(tpw): color tokens for tpw in mdv2

### DIFF
--- a/web-components/src/wc_scss/themes/global--dark.scss
+++ b/web-components/src/wc_scss/themes/global--dark.scss
@@ -102,4 +102,12 @@
   --md-scrollbar-background-hover-indicator: #{$white-48};
   --md-scrollbar-background-active-indicator: #{$white-60};
   --md-scrollbar-background-disabled-indicator: #{$white-12};
+
+  --md-table-primary-bg-color: #{$md-gray-80};
+  --md-table-header-bg-color: #{$md-gray-95};
+  --md-table-header-border-bottom: none;
+  --md-table-cell-border-bottom: 1px solid #{$mds-color-theme-outline-secondary-normal};
+  --md-table-border-style: solid;
+  --md-table-sub-nav-bg-color: #{$mds-color-theme-background-primary-ghost};
+  --md-table-vertical-divider-color: #{$mds-color-theme-outline-secondary-normal};
 }

--- a/web-components/src/wc_scss/themes/global--light.scss
+++ b/web-components/src/wc_scss/themes/global--light.scss
@@ -83,7 +83,7 @@
   --md-input-chat-length-indicator-color: #{$md-gray-70};
   --md-input-chat-bg-color: #{$md-white-100};
   --md-input-chat-color: #{$md-gray-100};
-  --md-input-chat-error-color: #A12512;
+  --md-input-chat-error-color: #a12512;
   --md-webex-chat-disable-bg-color: #{$md-gray-20};
   --md-webex-chat-disable-color: #{$md-gray-40};
 
@@ -102,4 +102,12 @@
   --md-scrollbar-background-hover-indicator: #{$black-48};
   --md-scrollbar-background-active-indicator: #{$black-60};
   --md-scrollbar-background-disabled-indicator: #{$black-12};
+
+  --md-table-primary-bg-color: #{$md-gray-20};
+  --md-table-header-bg-color: #{$md-gray-05};
+  --md-table-header-border-bottom: none;
+  --md-table-cell-border-bottom: 1px solid #{$mds-color-theme-outline-secondary-normal};
+  --md-table-border-style: solid;
+  --md-table-sub-nav-bg-color: #{$mds-color-theme-background-primary-ghost};
+  --md-table-vertical-divider-color: #{$mds-color-theme-outline-secondary-normal};
 }

--- a/web-components/src/wc_scss/themes/global--mdv2.scss
+++ b/web-components/src/wc_scss/themes/global--mdv2.scss
@@ -127,7 +127,6 @@ $inter-medium-font: "Inter Medium", $font-family-sans-serif;
   --md-scrollbar-background-active-indicator: #{$mds-color-theme-scrollbar-button-pressed};
   --md-scrollbar-background-disabled-indicator: #{$mds-color-theme-scrollbar-background-secondary-normal};
 
-
   // Background colours can not be overwritten because they are being used by consumers in unexpected ways
   // New background colours should be introduced and these phased out
   // --md-primary-bg-color: #{$mds-color-theme-background-solid-primary-normal};
@@ -163,4 +162,12 @@ $inter-medium-font: "Inter Medium", $font-family-sans-serif;
   // --md-input-chat-error-color: #{$md-red-50};
   // --md-webex-chat-disable-bg-color: #{$md-gray-90};
   // --md-webex-chat-disable-color: #{$md-gray-70};
+
+  // wxcc TPW colors
+  --md-tpw-primary-bg-color: transparent;
+  --md-tpw-header-border-bottom: 0 -1px 0 0 #{$mds-color-theme-outline-primary-normal} inset;
+  --md-tpw-cell-border-bottom: 1px solid #{$mds-color-theme-outline-secondary-normal};
+  --md-tpw-border-none: none;
+  --md-tpw-sub-nav-bg-color: #{$mds-color-theme-background-primary-hover};
+  --md-tpw-vertical-divider-color: #{$mds-color-theme-outline-secondary-normal};
 }

--- a/web-components/src/wc_scss/themes/global--mdv2.scss
+++ b/web-components/src/wc_scss/themes/global--mdv2.scss
@@ -127,6 +127,14 @@ $inter-medium-font: "Inter Medium", $font-family-sans-serif;
   --md-scrollbar-background-active-indicator: #{$mds-color-theme-scrollbar-button-pressed};
   --md-scrollbar-background-disabled-indicator: #{$mds-color-theme-scrollbar-background-secondary-normal};
 
+  --md-table-primary-bg-color: #{$mds-color-theme-background-primary-ghost};
+  --md-table-header-bg-color: #{$mds-color-theme-background-primary-ghost};
+  --md-table-header-border-bottom: 0 -1px 0 0 #{$mds-color-theme-outline-primary-normal} inset;
+  --md-table-cell-border-bottom: 1px solid #{$mds-color-theme-outline-secondary-normal};
+  --md-table-border-style: none;
+  --md-table-sub-nav-bg-color: #{$mds-color-theme-background-primary-hover};
+  --md-table-vertical-divider-color: #{$mds-color-theme-outline-secondary-normal};
+
   // Background colours can not be overwritten because they are being used by consumers in unexpected ways
   // New background colours should be introduced and these phased out
   // --md-primary-bg-color: #{$mds-color-theme-background-solid-primary-normal};
@@ -162,12 +170,4 @@ $inter-medium-font: "Inter Medium", $font-family-sans-serif;
   // --md-input-chat-error-color: #{$md-red-50};
   // --md-webex-chat-disable-bg-color: #{$md-gray-90};
   // --md-webex-chat-disable-color: #{$md-gray-70};
-
-  // wxcc TPW colors
-  --md-tpw-primary-bg-color: transparent;
-  --md-tpw-header-border-bottom: 0 -1px 0 0 #{$mds-color-theme-outline-primary-normal} inset;
-  --md-tpw-cell-border-bottom: 1px solid #{$mds-color-theme-outline-secondary-normal};
-  --md-tpw-border-none: none;
-  --md-tpw-sub-nav-bg-color: #{$mds-color-theme-background-primary-hover};
-  --md-tpw-vertical-divider-color: #{$mds-color-theme-outline-secondary-normal};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add color tokens for wxcc tpw in mdv2d

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
