### PR TITLE
add date range change event to DateRangePicker

### DIFF
--- a/web-components/src/components/date-range-picker/DateRangePicker.test.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.test.ts
@@ -71,6 +71,37 @@ describe("DatePicker Component", () => {
     expect(el.startDate).toEqual(secondDate.toSQLDate());
     expect(el.endDate).toEqual(firstDate.toSQLDate());
   });
+
+  test("should only emit date-range-change event when both start and end dates set", async () => {
+    const el: DateRangePicker.ELEMENT = new DateRangePicker.ELEMENT();
+    expect(el.startDate).toBeUndefined();
+    expect(el.endDate).toBeUndefined();
+
+    let capturedEvent: CustomEvent | null = null;
+    const eventSpy = jest.fn((event: CustomEvent) => {
+      capturedEvent = event;
+    });
+    el.addEventListener('date-range-change', eventSpy);
+
+    el.handleDateSelection({ detail: { data: DateTime.fromObject({ month: 1, day: 1 }) } });
+    expect(el.startDate).not.toBeUndefined();
+    expect(el.endDate).toBeUndefined();
+
+    expect(eventSpy).not.toHaveBeenCalled();
+    expect(capturedEvent).toBeNull();
+
+    el.handleDateSelection({ detail: { data: DateTime.fromObject({ month: 1, day: 2 }) } });
+    expect(el.startDate).not.toBeUndefined();
+    expect(el.startDate).not.toBeUndefined();
+
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+    expect(capturedEvent).not.toBeNull();
+    expect(capturedEvent!.detail).toEqual({
+      startDate: el.startDate,
+      endDate: el.endDate,
+    });
+  });
+
   describe("should handle range modification scenarios", () => {
     const startDate = DateTime.fromObject({ month: 11, day: 15 });
     const endDate = startDate.plus({ days: 5 });

--- a/web-components/src/components/date-range-picker/DateRangePicker.test.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.test.ts
@@ -80,8 +80,8 @@ describe("DatePicker Component", () => {
     let capturedEvent: CustomEvent | null = null;
     const eventSpy = jest.fn((event: CustomEvent) => {
       capturedEvent = event;
-    });
-    el.addEventListener('date-range-change', eventSpy);
+    }) as unknown as EventListener;
+    el.addEventListener('date-range-change', eventSpy as EventListener);
 
     el.handleDateSelection({ detail: { data: DateTime.fromObject({ month: 1, day: 1 }) } });
     expect(el.startDate).not.toBeUndefined();

--- a/web-components/src/components/date-range-picker/DateRangePicker.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.ts
@@ -80,8 +80,23 @@ export namespace DateRangePicker {
       } else {
         this.startDate = this.dateToSqlTranslate(e.detail.data);
       }
+      this.emitDateRange();
       this.updateValue();
     };
+
+    emitDateRange() {
+      if (!this.startDate || !this.endDate) {
+        return;
+      }
+      
+      const event = new CustomEvent("date-range-change", {
+        detail: {
+          startDate: this.startDate,
+          endDate: this.endDate,
+        },
+      });
+      this.dispatchEvent(event);
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Currently there appears to be no easy way for a consumer of the DateRangePicker component to get the startDate and endDate or listen to updates to these. Added a simple CustomEvent that emits both property values when they are set.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Makes using the component as a consumer easier.

## How Has This Been Tested?
Ran all the tests, and added annew one for new event. This change should not at all effect any current behaviour of the component.

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
