### PR TITLE
chore: add null checks to setFocusOnTrigger

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.14.19",
+  "version": "2.14.20",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/menu-overlay/MenuOverlay.ts
+++ b/web-components/src/components/menu-overlay/MenuOverlay.ts
@@ -422,7 +422,7 @@ export namespace MenuOverlay {
     }
 
     private focusOnNestedTrigger(triggerElement?: HTMLElement) {
-      this.setFocusOnTrigger!(triggerElement);
+      this.setFocusOnTrigger?.(triggerElement);
     }
 
     handleOutsideOverlayClick = (event: MouseEvent) => {

--- a/web-components/src/mixins/FocusTrapMixin.ts
+++ b/web-components/src/mixins/FocusTrapMixin.ts
@@ -243,7 +243,7 @@ export const FocusTrapMixin = <T extends AnyConstructor<FocusClass & FocusTrapCl
       return false;
     }
 
-    private findElement(activeElement: HTMLElement) {
+    private findElement(activeElement: HTMLElement): number {
       return this.focusableElements.findIndex((element) => this.isEqualFocusNode(activeElement, element));
     }
 
@@ -306,23 +306,35 @@ export const FocusTrapMixin = <T extends AnyConstructor<FocusClass & FocusTrapCl
      * @param   triggerElement  The trigger element.
      * @returns void
      */
-    protected setFocusOnTrigger(triggerElement: HTMLElement) {
-      let deepNestedTriggerElement;
-      if (triggerElement.shadowRoot!) {
-        deepNestedTriggerElement = this.findFocusable(triggerElement.shadowRoot!, new Set());
-      } else if (this.isFocusable(triggerElement)) {
-        deepNestedTriggerElement = [triggerElement];
-      } else {
-        deepNestedTriggerElement = this.findFocusable(triggerElement, new Set());
+    protected setFocusOnTrigger(triggerElement?: HTMLElement) {
+      if (!triggerElement) {
+        return;
       }
-      if (deepNestedTriggerElement[0]) {
-        const focusableIndex = this.findElement(deepNestedTriggerElement[0] as HTMLElement);
+
+      const deepNestedTriggerElement = this.getDeepNestedTriggerElement(triggerElement);
+
+      if (deepNestedTriggerElement.length > 0) {
+        const focusableIndex = this.findElement(deepNestedTriggerElement[0]);
         this.focusTrapIndex = focusableIndex;
       }
     }
 
+    private getDeepNestedTriggerElement(triggerElement: HTMLElement): HTMLElement[] {
+      if (triggerElement.shadowRoot) {
+        return this.findFocusable(triggerElement.shadowRoot, new Set());
+      } else if (this.isFocusable(triggerElement)) {
+        return [triggerElement];
+      } else {
+        return this.findFocusable(triggerElement, new Set());
+      }
+    }
+
     protected setFocusableElements() {
-      this.focusableElements = this.findFocusable(this.shadowRoot!, new Set());
+      if (this.shadowRoot) {
+        this.focusableElements = this.findFocusable(this.shadowRoot, new Set());
+      } else {
+        console.warn("shadow root is not available");
+      }
     }
 
     protected async firstUpdated(changedProperties: PropertyValues) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes an issue: CX-16951
Null check the trigger element in the focus trap mixin
Menu overlay sets focus on the trigger element. If this is null it will cause an exception

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
