### PR TITLE
chore: add themeManager to manager global theme

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.15.3",
+  "version": "2.16.0",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",
@@ -73,7 +73,9 @@
     "luxon": "^1.25.0",
     "nanoid": "^3.1.16",
     "papaparse": "^5.4.1",
-    "sortablejs": "^1.15.3"
+    "sortablejs": "^1.15.3",
+    "mobx": "^5.15.4",
+    "@adobe/lit-mobx": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.7",

--- a/web-components/src/[sandbox]/sandbox.ts
+++ b/web-components/src/[sandbox]/sandbox.ts
@@ -1,16 +1,11 @@
 import styles from "@/[sandbox]/sandbox.scss";
 import "@/components/sass-stats/SassStats";
 import { ThemeName } from "@/components/theme/Theme";
+import "@/components/theme/ThemeManager";
+import themeManager from "@/components/theme/ThemeManager";
 import reset from "@/wc_scss/reset.scss";
-import {
-  customElement,
-  html,
-  internalProperty,
-  LitElement,
-  property,
-  PropertyValues,
-  TemplateResult
-} from "lit-element";
+import { MobxLitElement } from "@adobe/lit-mobx";
+import { customElement, html, internalProperty, PropertyValues, TemplateResult } from "lit-element";
 import {
   accordionTemplate,
   advanceListTemplate,
@@ -69,13 +64,7 @@ import {
 } from "./examples";
 
 @customElement("momentum-ui-web-components-sandbox")
-export class Sandbox extends LitElement {
-  @property({ type: Boolean })
-  darkTheme = false;
-
-  @property({ type: String })
-  theme: ThemeName = "lumos";
-
+export class Sandbox extends MobxLitElement {
   @internalProperty()
   private selectedTab = "Accordion";
 
@@ -100,7 +89,7 @@ export class Sandbox extends LitElement {
 
   protected updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
-    if (this.darkTheme) {
+    if (themeManager.isDarkMode) {
       document.body.style.backgroundColor = "#000";
       document.body.style.color = "#fff";
     } else {
@@ -116,12 +105,12 @@ export class Sandbox extends LitElement {
   loadSettingsFromStorage() {
     const storedTheme = localStorage.getItem("theme");
     if (storedTheme) {
-      this.theme = storedTheme as ThemeName;
+      themeManager.setThemeName(storedTheme as ThemeName);
     }
 
     const storedDarkTheme = localStorage.getItem("darkTheme");
     if (storedDarkTheme) {
-      this.darkTheme = JSON.parse(storedDarkTheme);
+      themeManager.setDarkMode(JSON.parse(storedDarkTheme));
     }
   }
 
@@ -130,11 +119,11 @@ export class Sandbox extends LitElement {
     const target = composedPath[0] as unknown as HTMLOrSVGElement;
     const { aspect } = target.dataset;
     if (aspect === "lumos" || aspect === "momentumV2" || aspect === "momentum") {
-      this.theme = aspect;
-      localStorage.setItem("theme", this.theme);
+      themeManager.setThemeName(aspect);
+      localStorage.setItem("theme", themeManager.themeName);
     } else if (aspect === "darkTheme") {
-      this.darkTheme = !this.darkTheme;
-      localStorage.setItem("darkTheme", JSON.stringify(this.darkTheme));
+      themeManager.setDarkMode(!themeManager.isDarkMode);
+      localStorage.setItem("darkTheme", JSON.stringify(themeManager.isDarkMode));
     } else {
       console.error("Invalid data-aspect input");
       return;
@@ -151,7 +140,7 @@ export class Sandbox extends LitElement {
             class="theme-switch"
             data-aspect="darkTheme"
             @click=${this.toggleSetting}
-            ?checked=${this.darkTheme}
+            ?checked=${themeManager.isDarkMode}
           />
           Dark Mode
         </label>
@@ -162,7 +151,7 @@ export class Sandbox extends LitElement {
             class="momentum-switch"
             data-aspect="momentum"
             @click=${this.toggleSetting}
-            ?checked=${this.theme === "momentum"}
+            ?checked=${themeManager.themeName === "momentum"}
           />
           Momentum
         </label>
@@ -173,7 +162,7 @@ export class Sandbox extends LitElement {
             class="lumos-switch"
             data-aspect="lumos"
             @click=${this.toggleSetting}
-            ?checked=${this.theme === "lumos"}
+            ?checked=${themeManager.themeName === "lumos"}
           />
           Lumos
         </label>
@@ -184,7 +173,7 @@ export class Sandbox extends LitElement {
             class="momentumv2-switch"
             data-aspect="momentumV2"
             @click=${this.toggleSetting}
-            ?checked=${this.theme === "momentumV2"}
+            ?checked=${themeManager.themeName === "momentumV2"}
           />
           MomentumV2
         </label>
@@ -260,7 +249,12 @@ export class Sandbox extends LitElement {
 
   render() {
     return html`
-      <md-theme class="theme-toggle" id="app-theme" ?darkTheme=${this.darkTheme} theme=${this.theme}>
+      <md-theme
+        class="theme-toggle"
+        id="app-theme"
+        ?darkTheme=${themeManager.isDarkMode}
+        theme=${themeManager.themeName}
+      >
         <div class="header-controls">${this.themeToggle()} ${this.containerColorOptionTemplate()}</div>
 
         <md-tabs direction="vertical" class="explorer" persist-selection tabs-id="explorer">

--- a/web-components/src/components/theme/ThemeManager.ts
+++ b/web-components/src/components/theme/ThemeManager.ts
@@ -31,12 +31,6 @@ export class ThemeManager {
    */
   @observable isMomentumAvatarEnabled = false;
 
-  /**
-   * Observable property to indicate if Momentum Components are enabled
-   * Should be used set the newMomentum styles on components
-   */
-  @observable isMomentumComponentsEnabled = false;
-
   private static instance: ThemeManager;
 
   /**
@@ -66,10 +60,6 @@ export class ThemeManager {
 
   @action setMomentumAvatar(value: boolean) {
     this.isMomentumAvatarEnabled = value;
-  }
-
-  @action setMomentumComponents(value: boolean) {
-    this.isMomentumComponentsEnabled = value;
   }
 
   /**

--- a/web-components/src/components/theme/ThemeManager.ts
+++ b/web-components/src/components/theme/ThemeManager.ts
@@ -1,0 +1,85 @@
+import { action, computed, observable } from "mobx";
+import { ThemeName } from "./Theme";
+
+/**
+ * ThemeManager is a singleton class that manages the global theme state.
+ * It provides observable properties that can be observed by other classes
+ * to set properties on their components, such as whether dark mode is enabled.
+ */
+export class ThemeManager {
+  /**
+   * Observable property to indicate if dark mode is enabled
+   * Is needed by components styled outside of the web components
+   */
+  @observable isDarkMode = false;
+
+  /**
+   * Observable property to store the current theme name
+   */
+  @observable themeName: ThemeName = "lumos";
+
+  /**
+   * Observable property to indicate if visual rebrand is enabled
+   * Will be used to allow users to toggle to updated visuals
+   */
+  @observable isVisualRebrandEnabled = false;
+
+  /**
+   * Observable property to indicate if Momentum Avatar is enabled
+   * Should be used to set the new momentum style on avatars and sue
+   * correct momentum presence states
+   */
+  @observable isMomentumAvatarEnabled = false;
+
+  /**
+   * Observable property to indicate if Momentum Components are enabled
+   * Should be used set the newMomentum styles on components
+   */
+  @observable isMomentumComponentsEnabled = false;
+
+  private static instance: ThemeManager;
+
+  /**
+   * Returns the singleton instance of ThemeManager.
+   * If the instance does not exist, it creates a new one.
+   * @returns {ThemeManager} The singleton instance of ThemeManager
+   */
+  static getInstance(): ThemeManager {
+    if (!ThemeManager.instance) {
+      ThemeManager.instance = new ThemeManager();
+    }
+
+    return ThemeManager.instance;
+  }
+
+  @action setDarkMode(value: boolean) {
+    this.isDarkMode = value;
+  }
+
+  @action setThemeName(value: ThemeName) {
+    this.themeName = value;
+  }
+
+  @action setVisualRebrandEnabled(value: boolean) {
+    this.isVisualRebrandEnabled = value;
+  }
+
+  @action setMomentumAvatar(value: boolean) {
+    this.isMomentumAvatarEnabled = value;
+  }
+
+  @action setMomentumComponents(value: boolean) {
+    this.isMomentumComponentsEnabled = value;
+  }
+
+  /**
+   * Computed property to check if the current theme is Momentum V2.
+   * @returns {boolean} True if the current theme is Momentum V2, otherwise false
+   */
+  @computed get isMomentumV2Enabled() {
+    return this.themeName === "momentumV2";
+  }
+}
+
+const themeManager = ThemeManager.getInstance();
+export default themeManager;

--- a/web-components/src/index.ts
+++ b/web-components/src/index.ts
@@ -74,7 +74,7 @@ export { TabPanel } from "./components/tabs/TabPanel";
 export { Tabs } from "./components/tabs/Tabs";
 export { TaskItem } from "./components/taskitem/TaskItem";
 export { Theme, ThemeName } from "./components/theme/Theme";
-export { ThemeManager } from "./components/theme/ThemeManager";
+export { ThemeManager, default as themeManager } from "./components/theme/ThemeManager";
 export { TimePicker } from "./components/timepicker/TimePicker";
 export { ToggleSwitch } from "./components/toggle-switch/ToggleSwitch";
 export { Tooltip } from "./components/tooltip/Tooltip";

--- a/web-components/src/index.ts
+++ b/web-components/src/index.ts
@@ -74,6 +74,7 @@ export { TabPanel } from "./components/tabs/TabPanel";
 export { Tabs } from "./components/tabs/Tabs";
 export { TaskItem } from "./components/taskitem/TaskItem";
 export { Theme, ThemeName } from "./components/theme/Theme";
+export { ThemeManager } from "./components/theme/ThemeManager";
 export { TimePicker } from "./components/timepicker/TimePicker";
 export { ToggleSwitch } from "./components/toggle-switch/ToggleSwitch";
 export { Tooltip } from "./components/tooltip/Tooltip";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add themeManager for managing global theme state

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
