### PR TITLE
fix(release): allow combobox the option to turn off filtering

### DIFF
--- a/web-components/src/components/combobox/ComboBox.test.ts
+++ b/web-components/src/components/combobox/ComboBox.test.ts
@@ -1516,5 +1516,15 @@ describe("Combobox Component", () => {
       expect(el.selectedOptions.length).toEqual(1);
       expect(el.selectedOptions).toEqual(expect.arrayContaining(["Afghanistan"]));
     });
+
+    test("should preserve options list when preventFilter is true", async () => {
+      const el = await fixture<ComboBox.ELEMENT>(html`
+        <md-combobox .options=${comboBoxOptions} prevent-filter></md-combobox>
+      `);
+      el.inputValue = "Afghanistan";
+      await elementUpdated(el);
+      expect(el.filteredOptions.length).toEqual(comboBoxOptions.length);
+      expect(el.filteredOptions).toEqual(expect.arrayContaining(comboBoxOptions));
+    });
   });
 });

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -110,6 +110,7 @@ export namespace ComboBox {
     @property({ type: String, attribute: "popup-chevron-aria-hidden" }) popupChevronAriaHidden = "true";
     @property({ type: Boolean, reflect: true }) newMomentum = false;
     @property({ type: Boolean, attribute: "show-filter-icon" }) showFilterIcon = false;
+    @property({ type: Boolean, attribute: "prevent-filter" }) preventFilter = false;
 
     /**
      * When using the new momentum style sets whether to use the new combobox style arrow
@@ -563,6 +564,11 @@ export namespace ComboBox {
     };
 
     private filterOptions(value: string): (string | OptionMember)[] {
+      if(this.preventFilter)
+      {
+         this.searchItem = false;
+         return this.options;
+      }
       if (value && value.length) {
         const finalFilteredOption = this.options.filter((option: string | OptionMember) => {
           if (this.isOptGroup && typeof option !== "string" && option.isLabel === "true") {

--- a/web-components/src/components/timepicker/TimePicker.ts
+++ b/web-components/src/components/timepicker/TimePicker.ts
@@ -392,6 +392,7 @@ export namespace TimePicker {
           class="amPm-combo-box"
           .options=${options}
           .value=${[options[0]]}
+          .preventFilter=${true}
           .inputValue=${this.timeValue[TIME_UNIT.AM_PM]}
           .ariaLabel=${this.timeValue[TIME_UNIT.AM_PM]}
           @change-selected="${(e: CustomEvent) => this.handleTimeChange(e, TIME_UNIT.AM_PM)}"


### PR DESCRIPTION
fixes an Inconsistancy in timepicker where multiple options cannot be seen by the User.

## Description
Allowing the combo-box to turn on/off the filtering option. In the time-picker we use combo box for am/pm. We set the value explicitly, so when the User clicks on the am/pm dropdown, they are auto searching for that and hiding the other value. The use case here is to prevent that functionality when not required.

## Related Issue
https://jira-eng-sjc12.cisco.com/jira/browse/CX-17005

## Motivation and Context
Allows the component to be extensible for more use cases.

## How Has This Been Tested?
Manually and in Unit tests.

## Screenshots:
**Before** (If applicable):
<img width="85" alt="Screenshot 2024-11-25 at 09 38 28" src="https://github.com/user-attachments/assets/67e5aa95-892d-4e5b-a6c8-33549021ab61">

**After**:
<img width="149" alt="Screenshot 2024-11-25 at 09 26 47" src="https://github.com/user-attachments/assets/6c368591-17b4-47a5-9457-f589b8c42f2d">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
