### PR TITLE
# CX-17328 - fix(release): update event flow for date picker

### DIFF
--- a/web-components/src/components/date-time-picker/DateTimePicker.test.ts
+++ b/web-components/src/components/date-time-picker/DateTimePicker.test.ts
@@ -1,4 +1,4 @@
-import { fixture, fixtureCleanup, html } from "@open-wc/testing-helpers";
+import { elementUpdated, fixture, fixtureCleanup, html } from "@open-wc/testing-helpers";
 import { Settings } from "luxon";
 import "./DateTimePicker";
 import { DateTimePicker } from "./DateTimePicker";
@@ -37,19 +37,22 @@ describe("DateTimePicker Component", () => {
 
   test("should fire date-time-change when a blank value is passed from date-input-change", async () => {
     const el: DateTimePicker.ELEMENT = await fixture(html` <md-date-time-picker></md-date-time-picker>> `);
+    el.value = "2021-01-01T00:00:00-08:00";
     expect(el?.getAttribute("ariaLabel")).toBeNull();
     const eventSpy = jest.spyOn(el, "dispatchEvent");
     el.handleDateTimeInputChange(new CustomEvent("date-input-change", { detail: { value: "" } }));
     expect(el.value).toBe("");
+    await elementUpdated(el);
     expect(eventSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "date-time-change",
-        detail: expect.objectContaining({
-          dateTimeString: "",
-          dateTime: null,
-          locale: el.locale,
-          twentyFourHourFormat: el.twentyFourHourFormat
-        })
+      new CustomEvent(`date-time-change`, {
+          bubbles: true,
+          composed: true,
+          detail: {
+            dateTimeString: "",
+            dateTime: null,
+            locale: "en-US",
+            twentyFourHourFormat: false
+        }
       })
     );
   });

--- a/web-components/src/components/date-time-picker/DateTimePicker.test.ts
+++ b/web-components/src/components/date-time-picker/DateTimePicker.test.ts
@@ -34,4 +34,23 @@ describe("DateTimePicker Component", () => {
     const el: DateTimePicker.ELEMENT = await fixture(html` <md-date-time-picker></md-date-time-picker>> `);
     expect(el?.getAttribute("ariaLabel")).toBeNull();
   });
+
+  test("should fire date-time-change when a blank value is passed from date-input-change", async () => {
+    const el: DateTimePicker.ELEMENT = await fixture(html` <md-date-time-picker></md-date-time-picker>> `);
+    expect(el?.getAttribute("ariaLabel")).toBeNull();
+    const eventSpy = jest.spyOn(el, "dispatchEvent");
+    el.handleDateTimeInputChange(new CustomEvent("date-input-change", { detail: { value: "" } }));
+    expect(el.value).toBe("");
+    expect(eventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "date-time-change",
+        detail: expect.objectContaining({
+          dateTimeString: "",
+          dateTime: null,
+          locale: el.locale,
+          twentyFourHourFormat: el.twentyFourHourFormat
+        })
+      })
+    );
+  });
 });

--- a/web-components/src/components/date-time-picker/DateTimePicker.ts
+++ b/web-components/src/components/date-time-picker/DateTimePicker.ts
@@ -98,9 +98,7 @@ export namespace DateTimePicker {
     };
 
     handleDateTimeInputChange = (event: CustomEvent) => {
-      if (event?.detail?.value) {
-        this.value = event?.detail?.value;
-      }
+      this.value = event?.detail?.value;
     };
 
     parseValueForVisuals = (value: string) => {

--- a/web-components/src/components/date-time-picker/DateTimePicker.ts
+++ b/web-components/src/components/date-time-picker/DateTimePicker.ts
@@ -111,12 +111,10 @@ export namespace DateTimePicker {
     };
 
     updateDateTimeObject = () => {
-      
       if (this.value) {
         this.fullDateTime = DateTime.fromISO(this.value, { locale: this.locale });
       }
-      else
-      {
+      else{
         this.fullDateTime = DateTime.fromISO("", { locale: this.locale });;
       }
 

--- a/web-components/src/components/date-time-picker/DateTimePicker.ts
+++ b/web-components/src/components/date-time-picker/DateTimePicker.ts
@@ -63,8 +63,10 @@ export namespace DateTimePicker {
     protected updated(changedProperties: PropertyValues) {
       super.updated(changedProperties);
 
-      if (this.value && changedProperties.has("value")) {
-        this.parseValueForVisuals(this.value);
+      if (changedProperties.has("value")) {
+        if (this.value) {
+          this.parseValueForVisuals(this.value);
+        }
         if (!this.firstCycle) {
           this.updateDateTimeObject();
         } else {
@@ -109,21 +111,27 @@ export namespace DateTimePicker {
     };
 
     updateDateTimeObject = () => {
+      
       if (this.value) {
         this.fullDateTime = DateTime.fromISO(this.value, { locale: this.locale });
-        this.dispatchEvent(
-          new CustomEvent(`date-time-change`, {
-            bubbles: true,
-            composed: true,
-            detail: {
-              dateTimeString: this.value,
-              dateTime: this.fullDateTime,
-              locale: this.locale,
-              twentyFourHourFormat: this.twentyFourHourFormat
-            }
-          })
-        );
       }
+      else
+      {
+        this.fullDateTime = DateTime.fromISO("", { locale: this.locale });;
+      }
+
+      this.dispatchEvent(
+        new CustomEvent(`date-time-change`, {
+          bubbles: true,
+          composed: true,
+          detail: {
+            dateTimeString: this.value,
+            dateTime: this.fullDateTime,
+            locale: this.locale,
+            twentyFourHourFormat: this.twentyFourHourFormat
+          }
+        })
+      );
     };
 
     combineDateAndTimeValues = (dateString: string | undefined, timeString: string) => {

--- a/web-components/src/components/datepicker/DatePicker.test.ts
+++ b/web-components/src/components/datepicker/DatePicker.test.ts
@@ -94,4 +94,22 @@ describe("DatePicker Component", () => {
     `);
     expect(el).not.toBeNull();
   });
+
+  test("should update value and fire the date-input-change event when handleDateInputChange is called with an empty string", async () => {
+    const el: DatePicker.ELEMENT = await fixture(html` <md-datepicker></md-datepicker> `);
+    const eventSpy = jest.spyOn(el, "dispatchEvent");
+    const event = new CustomEvent("input-change", { detail: { value: "" } });
+    el.handleDateInputChange(event);
+    expect(el.value).toBe("");
+    expect(eventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bubbles: true,
+        composed: true,
+        detail: expect.objectContaining({
+          sourceEvent: event,
+          value: ""
+        })
+      })
+    );
+  });
 });

--- a/web-components/src/components/datepicker/DatePicker.test.ts
+++ b/web-components/src/components/datepicker/DatePicker.test.ts
@@ -102,13 +102,13 @@ describe("DatePicker Component", () => {
     el.handleDateInputChange(event);
     expect(el.value).toBe("");
     expect(eventSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
+      new CustomEvent("date-input-change",{
         bubbles: true,
         composed: true,
-        detail: expect.objectContaining({
+        detail: {
           sourceEvent: event,
           value: ""
-        })
+        }
       })
     );
   });

--- a/web-components/src/components/datepicker/DatePicker.ts
+++ b/web-components/src/components/datepicker/DatePicker.ts
@@ -103,10 +103,7 @@ export namespace DatePicker {
     }
 
     handleDateInputChange = (event: CustomEvent) => {
-      if (event?.detail?.value) {
-        this.value = event?.detail?.value;
-      }
-
+      this.value = event?.detail?.value;
       this.dispatchEvent(
         new CustomEvent("date-input-change", {
           bubbles: true,


### PR DESCRIPTION
Events need to propogate to the UI impl on blank values for dates. So that the UI can respond appropriately.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The if statement would ignore blank values, and the method flow would propogate the previous value, which is then ignored by DateTimePicker.ts in it's updated flow.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Makes sure any UI that implements this can respond if required to a blank value entering the input field for the date picker.

## How Has This Been Tested?
Manually(Sandbox) and in tests.

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
