### PR TITLE
chore: only render selected tab panel

### DIFF
--- a/web-components/src/[sandbox]/examples/avatar.ts
+++ b/web-components/src/[sandbox]/examples/avatar.ts
@@ -9,7 +9,7 @@ export class AvatarTemplateSandbox extends LitElement {
   @internalProperty()
   private isNewMomentumEnabled = false;
 
-  private toggleMomentum = () => {
+  private readonly toggleMomentum = () => {
     this.isNewMomentumEnabled = !this.isNewMomentumEnabled;
   };
 

--- a/web-components/src/[sandbox]/examples/chat-message.ts
+++ b/web-components/src/[sandbox]/examples/chat-message.ts
@@ -1,9 +1,10 @@
-import "@/components/chat-message/ChatMessage";
-import { html } from "lit-element";
+import "@/components/alert-banner/AlertBanner";
 import "@/components/alert/Alert";
 import "@/components/badge/Badge";
+import "@/components/chat-message/ChatMessage";
 import "@/components/icon/Icon";
-import "@/components/alert-banner/AlertBanner";
+import "@/components/tooltip/Tooltip";
+import { html } from "lit-element";
 
 export const chatMessageTemplate = html`
   <md-chat-message title="John Doe" time="11:27AM" status="Received">

--- a/web-components/src/assets/styles/fonts.css
+++ b/web-components/src/assets/styles/fonts.css
@@ -42,7 +42,7 @@
 @font-face {
   font-display: fallback;
   font-family: "Inter Thin Oblique";
-  font-style: 200;
+  font-style: oblique;
   font-weight: 400;
   src: url("../../fonts/Inter.var.woff2") format("woff2");
 }

--- a/web-components/src/components/breadcrumb/Breadcrumb.ts
+++ b/web-components/src/components/breadcrumb/Breadcrumb.ts
@@ -1,9 +1,9 @@
-import reset from "@/wc_scss/reset.scss";
 import { customElementWithCheck } from "@/mixins/CustomElementCheck";
+import reset from "@/wc_scss/reset.scss";
 import { html, LitElement, property, PropertyValues, queryAll } from "lit-element";
-import styles from "./scss/module.scss";
-import { repeat } from "lit-html/directives/repeat";
 import { ifDefined } from "lit-html/directives/if-defined";
+import { repeat } from "lit-html/directives/repeat";
+import styles from "./scss/module.scss";
 
 export namespace Breadcrumb {
   type NavCrumb = {
@@ -23,7 +23,7 @@ export namespace Breadcrumb {
     }
 
     private setLastAnchorCurrent() {
-      if (this.anchors && this.anchors.length) {
+      if (this.anchors?.length) {
         this.anchors[this.anchors.length - 1].setAttribute("aria-current", "page");
       }
     }
@@ -44,7 +44,7 @@ export namespace Breadcrumb {
     handleClick(event: MouseEvent) {
       const navCrumb = event.target as HTMLAnchorElement;
 
-      if (this.anchors && this.anchors.length) {
+      if (this.anchors?.length) {
         const navCrumbIndex = Array.from(this.anchors).indexOf(navCrumb);
         if (navCrumbIndex !== -1) {
           this.navCrumbs = [...this.navCrumbs.splice(0, navCrumbIndex + 1)];

--- a/web-components/src/components/button/Button.test.ts
+++ b/web-components/src/components/button/Button.test.ts
@@ -1,8 +1,9 @@
+import { Button } from "@/components/button/Button";
+import "@/components/icon/Icon";
 import { Key } from "@/constants";
 import { fixture, fixtureCleanup, html, oneEvent } from "@open-wc/testing-helpers";
 import { nothing } from "lit-html";
 import "./Button";
-import { Button } from "./Button";
 
 describe("Button Component", () => {
   afterEach(fixtureCleanup);

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -564,10 +564,9 @@ export namespace ComboBox {
     };
 
     private filterOptions(value: string): (string | OptionMember)[] {
-      if(this.preventFilter)
-      {
-         this.searchItem = false;
-         return this.options;
+      if (this.preventFilter) {
+        this.searchItem = false;
+        return this.options;
       }
       if (value && value.length) {
         const finalFilteredOption = this.options.filter((option: string | OptionMember) => {

--- a/web-components/src/components/link/Link.test.ts
+++ b/web-components/src/components/link/Link.test.ts
@@ -70,7 +70,7 @@ describe("Link component", () => {
     const component: Link.ELEMENT = await fixture(` <md-link tab-index="1"></md-link> `);
     expect(component.getAttribute("tab-index")).toEqual("1");
 
-    const linkShadow = component!.shadowRoot!.querySelector(".md-link");
+    const linkShadow = component.shadowRoot!.querySelector(".md-link");
     expect(linkShadow!.getAttribute("tabindex")).toContain("1");
   });
 
@@ -79,7 +79,7 @@ describe("Link component", () => {
     const component: Link.ELEMENT = await fixture<Link.ELEMENT>(` <md-link tab-index="1" disabled></md-link> `);
     expect(component.disabled).toBeTruthy();
 
-    const linkShadow = component!.shadowRoot!.querySelector(".md-link");
+    const linkShadow = component.shadowRoot!.querySelector(".md-link");
     expect(linkShadow!.getAttribute("aria-disabled")).toBeTruthy;
   });
 

--- a/web-components/src/components/popover/Popover.ts
+++ b/web-components/src/components/popover/Popover.ts
@@ -367,7 +367,7 @@ export namespace Popover {
       return false;
     }
 
-    private setIsOpenDebounced = debounce((flag: boolean) => {
+    private readonly setIsOpenDebounced = debounce((flag: boolean) => {
       this.isOpen = flag;
     }, 100);
 

--- a/web-components/src/components/tabs/Tabs.ts
+++ b/web-components/src/components/tabs/Tabs.ts
@@ -56,7 +56,15 @@ export namespace Tabs {
     @property({ type: Boolean, attribute: "draggable" }) draggable = false;
     @property({ type: String }) direction: "horizontal" | "vertical" = "horizontal";
     @property({ type: Number, attribute: "more-items-scroll-limit" }) moreItemsScrollLimit = Number.MAX_SAFE_INTEGER;
-    @property({ type: Number, reflect: true, attribute: "selected-index" }) selectedIndex = 0;
+
+    private _selectedIndex = 0;
+    @property({ type: Number, reflect: true, attribute: "selected-index" })
+    get selectedIndex(): number {
+      return this._selectedIndex;
+    }
+    set selectedIndex(value: number) {
+      this._selectedIndex = value;
+    }
     @property({ type: Number }) delay = 0;
     @property({ type: Number }) animation = 100;
     @property({ type: String, attribute: "ghost-class" }) ghostClass = "";
@@ -131,6 +139,12 @@ export namespace Tabs {
 
     private visibleTabsSortableInstance: Sortable | null = null;
     private hiddenTabsSortableInstance: Sortable | null = null;
+
+    private get currentTabsLayout(): Tab.ELEMENT[] {
+      return this.direction === "horizontal"
+        ? [...this.tabsFilteredAsVisibleList, ...this.tabsFilteredAsHiddenList]
+        : this.tabs;
+    }
 
     private getCopyTabId(tab: Tab.ELEMENT) {
       if (tab.id?.startsWith(MORE_MENU_TAB_COPY_ID_PREFIX)) {
@@ -256,10 +270,7 @@ export namespace Tabs {
 
             let isTabsFitInViewport = true;
             if (tabsListViewportOffsetWidth < tabsTotalOffsetWidth) {
-              // console.log("Applied More button");
               isTabsFitInViewport = false;
-            } else {
-              // console.log("Removed More button");
             }
 
             const newTabsViewportList: TabsViewportDataList = [];
@@ -613,37 +624,36 @@ export namespace Tabs {
       this.requestUpdate();
     }
 
+    private toggleSelectedAttribute(tab?: Tab.ELEMENT, tabPanel?: TabPanel.ELEMENT) {
+      tab?.toggleAttribute("selected");
+      tabPanel?.toggleAttribute("selected");
+
+      if (tab) {
+        const tabCopy = this.tabsCopyHash[this.getCopyTabId(tab)];
+        if (tabCopy) {
+          tabCopy.toggleAttribute("selected");
+          this.isMoreTabMenuSelected = true;
+        } else {
+          this.isMoreTabMenuSelected = false;
+        }
+      }
+    }
+
     private updateSelectedTab(newSelectedIndex: number) {
       const { tabs, panels } = this;
       const oldSelectedIndex = this.tabs.findIndex((element) => element.hasAttribute("selected"));
-      if (oldSelectedIndex === -1) {
-        return;
-      }
 
       if (tabs && panels) {
         [oldSelectedIndex, newSelectedIndex].forEach((index) => {
-          const tab = tabs[index];
-          tab?.toggleAttribute("selected");
-          const panel = panels[index];
-          panel?.toggleAttribute("selected");
-          if (tab) {
-            const tabCopy = this.tabsCopyHash[this.getCopyTabId(tab)];
-            if (tabCopy) {
-              tabCopy.toggleAttribute("selected");
-              this.isMoreTabMenuSelected = true;
-            } else {
-              this.isMoreTabMenuSelected = false;
-            }
+          if (index >= 0) {
+            this.toggleSelectedAttribute(tabs[index], panels[index]);
           }
         });
       }
 
       if (newSelectedIndex >= 0) {
         this.dispatchSelectedChangedEvent(newSelectedIndex);
-        const currentTabsConfiguration =
-          this.direction === "horizontal"
-            ? [...this.tabsFilteredAsVisibleList, ...this.tabsFilteredAsHiddenList]
-            : this.tabs;
+        const currentTabsConfiguration = this.currentTabsLayout;
         const newSelectedTabIdx = currentTabsConfiguration.findIndex(
           (element) => element.id === tabs[newSelectedIndex].id
         );
@@ -652,10 +662,7 @@ export namespace Tabs {
     }
 
     private dispatchSelectedChangedEvent(newSelectedIndex: number) {
-      const currentTabsOrder =
-        this.direction === "horizontal"
-          ? [...this.tabsFilteredAsVisibleList, ...this.tabsFilteredAsHiddenList]
-          : this.tabs;
+      const currentTabsOrder = this.currentTabsLayout;
       const newSelectedTabId = this.tabs[newSelectedIndex].id;
       const newIndex = currentTabsOrder.findIndex((element) => element.id === newSelectedTabId);
 
@@ -1015,9 +1022,10 @@ export namespace Tabs {
           selectedTabIndex = idx > -1 ? idx : this.selected;
         }
 
-        const currentTabsLayout = [...this.tabsFilteredAsVisibleList, ...this.tabsFilteredAsHiddenList];
-        if (currentTabsLayout.length && currentTabsLayout[selectedTabIndex].id) {
-          this.handleNewSelectedTab(currentTabsLayout[selectedTabIndex].id);
+        const tabsLayout = this.currentTabsLayout;
+        if (tabsLayout.length && tabsLayout[selectedTabIndex].id) {
+          this._selectedIndex = selectedTabIndex;
+          this.handleNewSelectedTab(tabsLayout[selectedTabIndex].id);
         } else {
           this.selected = selectedTabIndex;
         }

--- a/web-components/src/components/tooltip/Tooltip.ts
+++ b/web-components/src/components/tooltip/Tooltip.ts
@@ -22,7 +22,7 @@ export type TooltipEvent = {
   placement: Tooltip.Placement;
   reference: HTMLElement;
   popper: HTMLElement;
-  slotContent?: Element[] | undefined | null;
+  slotContent?: Element[] | null;
 };
 
 export namespace Tooltip {
@@ -41,11 +41,11 @@ export namespace Tooltip {
 
     private slotContent: Element[] | null = null;
 
-    private _keyDownListener = (e: KeyboardEvent) => {
+    private readonly _keyDownListener = (e: KeyboardEvent) => {
       this.handleKeyDown(e);
     };
 
-    private _wheelListener = (_e: Event) => {
+    private readonly _wheelListener = (_e: Event) => {
       if (this.opened) {
         this.notifyTooltipDestroy();
       }

--- a/web-components/src/mixins/FocusMixin.ts
+++ b/web-components/src/mixins/FocusMixin.ts
@@ -114,7 +114,7 @@ export const FocusMixin = <T extends AnyConstructor<FocusClass>>(base: T): T & A
 
     protected getDeepActiveElement() {
       let host = document.activeElement || document.body;
-      while (host && host.shadowRoot && host.shadowRoot.activeElement) {
+      while (host?.shadowRoot?.activeElement) {
         host = host.shadowRoot.activeElement;
       }
       return host;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* When running the sandbox every tabpanel render function is called on startup by changing this so only the selected tab is rendered (which is configurable) it will help with faster load times and debugging of issues in individual tabs

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
