### PR TITLE
chore: add legacy test compatibility to tab

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/tabs/Tab.test.ts
+++ b/web-components/src/components/tabs/Tab.test.ts
@@ -100,4 +100,16 @@ describe("Tab", () => {
     expect(spySelected).toHaveBeenCalled();
     spySelected.mockRestore();
   });
+  
+  test("add test compatibility button for legacy tests", async () => {
+    const el = await fixture<Tab.ELEMENT>(`<md-tab></md-tab>`);
+    const spyHandleClick = jest.spyOn(el, "handleClick");
+
+    const legacyButton = el.shadowRoot?.querySelector<HTMLElement>("button");
+    legacyButton?.click();
+    
+    expect(spyHandleClick).toHaveBeenCalled();
+
+    spyHandleClick.mockRestore();
+  });
 });

--- a/web-components/src/components/tabs/Tab.ts
+++ b/web-components/src/components/tabs/Tab.ts
@@ -240,6 +240,14 @@ export namespace Tab {
           <slot class="tab-slot"></slot>
           ${this.isCrossVisible && this.closable ? this.renderCrossButton() : ""}
         </div>
+        <!-- Invisible button for legacy third party test compatibility -->
+        <button
+          type="button"
+          class="test-compatibility-button"
+          aria-hidden="true"          
+          @click=${(e: MouseEvent) => this.handleClick(e)}
+          @keydown=${(e: KeyboardEvent) => this.handleKeydown(e)}
+        ></button>
       `;
     }
   }

--- a/web-components/src/components/tabs/scss/tab.scss
+++ b/web-components/src/components/tabs/scss/tab.scss
@@ -44,6 +44,10 @@
   }
 }
 
+.test-compatibility-button {
+  display: none;
+}
+
 .tab-content.primary {
   color: var(--tabs-default-text-color);
   font-family: var(--brand-font-medium);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add legacy third party test compatibility hidden button

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
