### PR TITLE
#CX-18460: Make date range picker startDate/endDate auto-update value

### DIFF
--- a/web-components/src/[sandbox]/examples/date-range-picker.ts
+++ b/web-components/src/[sandbox]/examples/date-range-picker.ts
@@ -37,7 +37,6 @@ export const dateRangePickerTemplate = html`
   <md-date-range-picker
     .controlButtons=${{ apply: { value: "Apply" }, cancel: { value: "Cancel" } }}
     .shouldCloseOnSelect=${true}
-    value=${datePickerValue}
     newMomentum
   ></md-date-range-picker>
 `;

--- a/web-components/src/components/date-range-picker/DateRangePicker.test.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.test.ts
@@ -143,6 +143,23 @@ describe("DatePicker Component", () => {
     const date3 = date2.plus({ days: 10 });
     const date4 = date3.plus({ days: 10 });
 
+    test("changing start and endDates automatically updates value", async () => {
+      const el: DateRangePicker.ELEMENT = await fixture(html`
+        <md-date-range-picker
+          .startDate=${date1.toSQLDate()}
+          .endDate=${date2.toSQLDate()}
+        ></md-date-range-picker>
+      `);
+      await el.updateComplete;
+      expect(el.value).toEqual(`${date1.toSQLDate()?.replace(/-/g, "/")} - ${date2.toSQLDate()?.replace(/-/g, "/")}`);
+      const newStartDate = date3.toSQLDate();
+      const newEndDate = date4.toSQLDate();
+      el.startDate = newStartDate;
+      el.endDate = newEndDate;
+      await el.updateComplete;
+      expect(el.value).toEqual(`${newStartDate?.replace(/-/g, "/")} - ${newEndDate?.replace(/-/g, "/")}`);
+    });
+
     test.each([
       [date1, date2, date3, date4],
       [date4, date3, date2, date1],

--- a/web-components/src/components/date-range-picker/DateRangePicker.test.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.test.ts
@@ -143,7 +143,7 @@ describe("DatePicker Component", () => {
     const date3 = date2.plus({ days: 10 });
     const date4 = date3.plus({ days: 10 });
 
-    test("changing start and endDates automatically updates value", async () => {
+    test("changing start and/or endDates automatically updates value", async () => {
       const el: DateRangePicker.ELEMENT = await fixture(html`
         <md-date-range-picker
           .startDate=${date1.toSQLDate()}
@@ -152,12 +152,18 @@ describe("DatePicker Component", () => {
       `);
       await el.updateComplete;
       expect(el.value).toEqual(`${date1.toSQLDate()?.replace(/-/g, "/")} - ${date2.toSQLDate()?.replace(/-/g, "/")}`);
+      
       const newStartDate = date3.toSQLDate();
       const newEndDate = date4.toSQLDate();
       el.startDate = newStartDate;
       el.endDate = newEndDate;
       await el.updateComplete;
       expect(el.value).toEqual(`${newStartDate?.replace(/-/g, "/")} - ${newEndDate?.replace(/-/g, "/")}`);
+
+      const newStartDate2 = date1.toSQLDate();
+      el.startDate = newStartDate2;
+      await el.updateComplete;
+      expect(el.value).toEqual(`${newStartDate2?.replace(/-/g, "/")} - ${newEndDate?.replace(/-/g, "/")}`);
     });
 
     test.each([

--- a/web-components/src/components/date-range-picker/DateRangePicker.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.ts
@@ -33,6 +33,14 @@ export namespace DateRangePicker {
       this.removeEventListener("date-pre-selection-change", this.handleDateSelection);
     }
 
+    updated(changedProperties: Map<string | number | symbol, unknown>) {
+      super.updated(changedProperties);
+    
+      if (changedProperties.has("startDate") || changedProperties.has("endDate")) {
+        this.updateValue();
+      }
+    }
+
     updateValue = () => {
       if (this.startDate && this.endDate) {
         this.value = `${reformatDateString(this.startDate)} - ${reformatDateString(this.endDate)}`;


### PR DESCRIPTION
Follow up to https://github.com/momentum-design/momentum-ui/pull/1907/

## Description
See title

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
