### PR TITLE
Expand/collapse Cardv2

### DIFF
--- a/web-components/src/components/card-v2/CardV2.test.ts
+++ b/web-components/src/components/card-v2/CardV2.test.ts
@@ -110,7 +110,7 @@ describe("Card-v2 component", () => {
     expect(footer?.classList.contains("hidden")).toBe(true);
   });
 
-  it("Toggling expand card should dispatch its event", async () => {
+  it("Toggling expand card from expand button should dispatch its event", async () => {
     const element: CardV2.ELEMENT = await fixtureFactory(
       CardState.ACTIVE,
       "123",
@@ -135,5 +135,59 @@ describe("Card-v2 component", () => {
 
     expect(eventSpy).toHaveBeenCalled();
     expect(info?.name).toBe("arrow-circle-down-bold");
+  });
+
+  it("Toggling expand card from card background should dispatch its event", async () => {
+    const element: CardV2.ELEMENT = await fixtureFactory(
+      CardState.ACTIVE,
+      "123",
+      "Test Title",
+      "Test Info",
+      "Test Data",
+      true
+    );
+
+    const cardBackground = element.shadowRoot?.querySelector(".md-card-v2") as HTMLElement;
+    expect(cardBackground).not.toBeNull();
+
+    const eventSpy = jest.fn();
+    element.addEventListener("expand-card-toggled", eventSpy);
+
+    const info = element.shadowRoot?.querySelector(".md-card-v2-footer md-icon") as HTMLButtonElement;
+    expect(info).not.toBeNull();
+    expect(info?.name).toBe("arrow-circle-up-bold");
+
+    cardBackground?.click();
+    await elementUpdated(element);
+
+    expect(eventSpy).toHaveBeenCalled();
+    expect(info?.name).toBe("arrow-circle-down-bold");
+  });
+
+  it("Card background should not be clickable when card is not expandable", async () => {
+    const element: CardV2.ELEMENT = await fixtureFactory(
+      CardState.ACTIVE,
+      "123",
+      "Test Title",
+      "Test Info",
+      "Test Data",
+      false
+    );
+
+    const cardBackground = element.shadowRoot?.querySelector(".md-card-v2") as HTMLElement;
+    expect(cardBackground).not.toBeNull();
+
+    const eventSpy = jest.fn();
+    element.addEventListener("expand-card-toggled", eventSpy);
+
+    const info = element.shadowRoot?.querySelector(".md-card-v2-footer md-icon") as HTMLButtonElement;
+    expect(info).not.toBeNull();
+    expect(info?.name).toBe("arrow-circle-up-bold");
+
+    cardBackground?.click();
+    await elementUpdated(element);
+
+    expect(eventSpy).not.toHaveBeenCalled();
+    expect(info?.name).toBe("arrow-circle-up-bold");
   });
 });

--- a/web-components/src/components/card-v2/CardV2.ts
+++ b/web-components/src/components/card-v2/CardV2.ts
@@ -75,6 +75,10 @@ export namespace CardV2 {
       };
     }
 
+    private get expandCardHandler() {
+      return this.expandable ? this.expandCardToggled : null;
+    }
+
     private renderHeader() {
       return html`
         <div class="md-card-v2-header-title">
@@ -95,7 +99,7 @@ export namespace CardV2 {
     private renderFooter() {
       return html`
         <div class="${classMap(this.footerClassMap)}">
-          <md-button ariaLabel="" circle size="28" @click=${this.expandCardToggled}>
+          <md-button ariaLabel="" circle size="28" >
             <md-icon
               slot="icon"
               iconSet="momentumDesign"
@@ -110,7 +114,7 @@ export namespace CardV2 {
 
     render() {
       return html`
-        <div class="${classMap(this.cardClassMap)}">
+        <div class="${classMap(this.cardClassMap)}" @click=${this.expandCardHandler} >
           <div class="md-card-v2-header">${this.renderHeader()}</div>
           <div class="${classMap(this.contentClassMap)}">
             <h2>${this.data}</h2>

--- a/web-components/src/components/card-v2/scss/card-v2.scss
+++ b/web-components/src/components/card-v2/scss/card-v2.scss
@@ -26,6 +26,7 @@
             justify-content: center;
             flex: 1 1 100%;
             flex-direction: column;
+            user-select: none;
 
             &-title {
                 display: flex;
@@ -52,6 +53,7 @@
             display: flex;
             flex: 1;
             gap: 8px;
+            user-select: none;
 
             h2 {
                 font-size: $md-card-v2-content-font-size;


### PR DESCRIPTION
Allow the Cardv2 to be clickable from anywhere on the card background (feedback from testing and agreed with the Applause team) - user can also still navigation to the expand/collapse button using the keyboard.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
