### PR TITLE
#CX-19330: fix date range picker screen reader labels

### DIFF
--- a/web-components/src/[sandbox]/examples/date-range-picker.ts
+++ b/web-components/src/[sandbox]/examples/date-range-picker.ts
@@ -51,6 +51,12 @@ export class DateRangePickerExample extends LitElement {
       <md-date-range-picker weekStart="Monday" value=${this.datePickerValue} disabled></md-date-range-picker>
       <h3>error date picker</h3>
       <md-date-range-picker newMomentum></md-date-range-picker>
+      <h3>date picker with custom ariaLabel</h3>
+      <md-date-range-picker
+        .ariaLabel=${`Custom aria label. Currently selected range is ${this.startDate} to ${this.endDate}`}
+        .startDate=${this.startDate}
+        .endDate=${this.endDate}>
+      </md-date-range-picker>
       <h3>date range picker with accept and cancel buttons</h3>
       <md-date-range-picker
         .startDate=${this.startDate}

--- a/web-components/src/[sandbox]/examples/datepicker.ts
+++ b/web-components/src/[sandbox]/examples/datepicker.ts
@@ -47,7 +47,7 @@ export const datePickerTemplate = html`
   <md-datepicker weekStart="Monday" value="2021-01-31"></md-datepicker>
   <h3>disabled datepicker</h3>
   <md-datepicker weekStart="Monday" value="2021-01-31" disabled></md-datepicker>
-  <h3>Call Date</h3>
+  <h3>Call Date (with custom aria label)</h3>
   <md-datepicker ariaLabel="Call Date" weekStart="Monday" value="2021-01-31"></md-datepicker>
   <h3>datepicker with initial value compact newMomentum</h3>
   <md-datepicker weekStart="Monday" value="2021-01-31" compact-input newMomentum></md-datepicker>

--- a/web-components/src/components/date-range-picker/DateRangePicker.test.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.test.ts
@@ -309,7 +309,7 @@ describe("DatePicker Component", () => {
       );
 
     test.each([
-      { useISOFormat: true, locale: "en-US", placeholder: undefined, expected: "YYYY/MM/DD - YYYY/MM/DD" },
+      { useISOFormat: true, locale: "en-US", placeholder: undefined, expected: "YYYY-MM-DD - YYYY-MM-DD" },
       { useISOFormat: true, locale: "en-US", placeholder: "FOOBAR", expected: "FOOBAR" },
       { useISOFormat: false, locale: "en-US", placeholder: undefined, expected: "M/D/YYYY - M/D/YYYY" },
       { useISOFormat: false, locale: "fr-FR", placeholder: undefined, expected: "DD/MM/YYYY - DD/MM/YYYY" },

--- a/web-components/src/components/date-range-picker/DateRangePicker.test.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.test.ts
@@ -281,6 +281,22 @@ describe("DatePicker Component", () => {
     });
   });
 
+
+  test("should use default aria label if no ariaLabel prop is set", async () => {
+    Settings.defaultLocale = "en-US";
+    const el = await fixture(html` <md-date-range-picker start-date="2024-12-01" end-date="2024-12-15"></md-date-range-picker> `);
+    const input = el.shadowRoot?.querySelector("md-input");
+    expect(input).not.toBeNull();
+    expect(input?.ariaLabel).toBe("Choose Date Range, currently selected range is December 1, 2024 to December 15, 2024");
+  });
+
+  test("should use custom aria label if ariaLabel prop is set", async () => {
+    const el = await fixture(html` <md-date-range-picker ariaLabel="Custom aria label" startDate="2024-12-01" endDate="2024-12-15"></md-date-range-picker> `);
+    const input = el.shadowRoot?.querySelector("md-input");
+    expect(input).not.toBeNull();
+    expect(input?.ariaLabel).toBe("Custom aria label");
+  });
+
   describe("Localised + ISO format testing", () => {
     test.each([
         { useISOFormat: true},

--- a/web-components/src/components/date-range-picker/DateRangePicker.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.ts
@@ -14,7 +14,7 @@ import { DatePicker } from "../datepicker/DatePicker";
 
 const DATE_RANGE_SEPARATOR = " - ";
 const DEFAULT_ARIA_LABEL = "Choose Date Range"
-const DEFAULT_ARIA_LABEL_RANGE_SELECTED = "Choose Date Range, currently selected range is"
+const DEFAULT_ARIA_LABEL_RANGE_SELECTED = "Choose Date Range, currently selected range is "
 
 export namespace DateRangePicker {
   @customElementWithCheck("md-date-range-picker")
@@ -104,7 +104,7 @@ export namespace DateRangePicker {
         const startDateISO = DateTime.fromISO(this.startDate);
         const endDateISO = DateTime.fromISO(this.endDate);
         if (startDateISO.isValid && endDateISO.isValid) {
-          return `${DEFAULT_ARIA_LABEL_RANGE_SELECTED}  ${startDateISO.toLocaleString(DateTime.DATE_FULL)} to ${endDateISO.toLocaleString(DateTime.DATE_FULL)}`; // TODO is the "to" alright here? ort should we havbe a template for the default range
+          return `${DEFAULT_ARIA_LABEL_RANGE_SELECTED}${startDateISO.toLocaleString(DateTime.DATE_FULL)} to ${endDateISO.toLocaleString(DateTime.DATE_FULL)}`; // TODO is the "to" alright here? ort should we havbe a template for the default range
         }
       }
       return DEFAULT_ARIA_LABEL;

--- a/web-components/src/components/date-range-picker/DateRangePicker.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.ts
@@ -17,6 +17,8 @@ const DATE_RANGE_SEPARATOR = " - ";
 export namespace DateRangePicker {
   @customElementWithCheck("md-date-range-picker")
   export class ELEMENT extends DatePicker.ELEMENT {
+    @property({ type: String }) ariaLabel = "Choose Date Range";
+    
     @property({ type: String, attribute: "start-date", reflect: true })
     startDate: string | undefined | null = undefined;
 
@@ -63,7 +65,7 @@ export namespace DateRangePicker {
         return this.placeholder;
       }
       if (this.useISOFormat) {
-        return `YYYY/MM/DD${DATE_RANGE_SEPARATOR}YYYY/MM/DD`;
+        return `YYYY-MM-DD${DATE_RANGE_SEPARATOR}YYYY-MM-DD`;
       }
       const placeholder = getLocaleDateFormat(this.locale).toUpperCase();
       return `${placeholder}${DATE_RANGE_SEPARATOR}${placeholder}`;
@@ -94,6 +96,23 @@ export namespace DateRangePicker {
       if (this.shouldCloseOnSelect) {
         this.setOpen(false);
       }
+    }
+
+    // overload
+    protected getAriaLabel(): string {
+      return this.ariaLabel + this.getDateRangeAriaLabel();
+    }
+
+    private getDateRangeAriaLabel(): string {
+      if (this.startDate && this.endDate) {
+        const startDateISO = DateTime.fromISO(this.startDate);
+        const endDateISO = DateTime.fromISO(this.endDate);
+        if (startDateISO.isValid && endDateISO.isValid) {
+          return `, selected date range is ${startDateISO.toLocaleString(DateTime.DATE_FULL)} to ${endDateISO.toLocaleString(DateTime.DATE_FULL)}`;
+        }
+      }
+
+      return "";
     }
 
     handleDateSelection(e: any): void {

--- a/web-components/src/components/date-range-picker/DateRangePicker.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.ts
@@ -13,12 +13,12 @@ import { DateTime } from "luxon";
 import { DatePicker } from "../datepicker/DatePicker";
 
 const DATE_RANGE_SEPARATOR = " - ";
+const DEFAULT_ARIA_LABEL = "Choose Date Range"
+const DEFAULT_ARIA_LABEL_RANGE_SELECTED = "Choose Date Range, currently selected range is"
 
 export namespace DateRangePicker {
   @customElementWithCheck("md-date-range-picker")
-  export class ELEMENT extends DatePicker.ELEMENT {
-    @property({ type: String }) ariaLabel = "Choose Date Range";
-    
+  export class ELEMENT extends DatePicker.ELEMENT {   
     @property({ type: String, attribute: "start-date", reflect: true })
     startDate: string | undefined | null = undefined;
 
@@ -99,19 +99,15 @@ export namespace DateRangePicker {
     }
 
     // overload
-    protected getAriaLabel(): string {
-      return this.ariaLabel + this.getDateRangeAriaLabel();
-    }
-
-    private getDateRangeAriaLabel(): string {
+    protected getDefaultAriaLabel = (): string => {
       if (this.startDate && this.endDate) {
         const startDateISO = DateTime.fromISO(this.startDate);
         const endDateISO = DateTime.fromISO(this.endDate);
         if (startDateISO.isValid && endDateISO.isValid) {
-          return `, selected date range is ${startDateISO.toLocaleString(DateTime.DATE_FULL)} to ${endDateISO.toLocaleString(DateTime.DATE_FULL)}`;
+          return `${DEFAULT_ARIA_LABEL_RANGE_SELECTED}  ${startDateISO.toLocaleString(DateTime.DATE_FULL)} to ${endDateISO.toLocaleString(DateTime.DATE_FULL)}`; // TODO is the "to" alright here? ort should we havbe a template for the default range
         }
       }
-      return "";
+      return DEFAULT_ARIA_LABEL;
     }
 
     handleDateSelection(e: any): void {

--- a/web-components/src/components/date-range-picker/DateRangePicker.ts
+++ b/web-components/src/components/date-range-picker/DateRangePicker.ts
@@ -111,7 +111,6 @@ export namespace DateRangePicker {
           return `, selected date range is ${startDateISO.toLocaleString(DateTime.DATE_FULL)} to ${endDateISO.toLocaleString(DateTime.DATE_FULL)}`;
         }
       }
-
       return "";
     }
 

--- a/web-components/src/components/datepicker/DatePicker.test.ts
+++ b/web-components/src/components/datepicker/DatePicker.test.ts
@@ -305,7 +305,7 @@ describe("DatePicker Component", () => {
     );
 
     test.each([
-      { useISOFormat: true, locale: "en-US", placeholder: undefined, expected: "YYYY/MM/DD" },
+      { useISOFormat: true, locale: "en-US", placeholder: undefined, expected: "YYYY-MM-DD" },
       { useISOFormat: true, locale: "en-US", placeholder: "FOOBAR", expected: "FOOBAR" },
       { useISOFormat: false, locale: "en-US", placeholder: undefined, expected: "M/D/YYYY" },
       { useISOFormat: false, locale: "fr-FR", placeholder: undefined, expected: "DD/MM/YYYY" },

--- a/web-components/src/components/datepicker/DatePicker.test.ts
+++ b/web-components/src/components/datepicker/DatePicker.test.ts
@@ -230,7 +230,7 @@ describe("DatePicker Component", () => {
     expect(mdInput?.value).toBe("");
     expect(mdInput?.value).not.toBeNull();
     const input = mdInput?.shadowRoot?.querySelector("input");
-    expect(input?.getAttribute("placeholder")).toBe("YYYY/MM/DD");
+    expect(input?.getAttribute("placeholder")).toBe("YYYY-MM-DD");
 
   });
 

--- a/web-components/src/components/datepicker/DatePicker.test.ts
+++ b/web-components/src/components/datepicker/DatePicker.test.ts
@@ -206,6 +206,25 @@ describe("DatePicker Component", () => {
     expect(el).not.toBeNull();
   });
 
+  test("should use default aria label if no ariaLabel prop is set", async () => {
+    Settings.defaultLocale = "en-US";
+    const el: DatePicker.ELEMENT = await createFixture(html`
+      <md-datepicker value="2024-05-01"></md-datepicker>
+    `);
+    const input = el.shadowRoot?.querySelector("md-input");
+    expect(input).not.toBeNull();
+    expect(input?.ariaLabel).toBe("Choose Date, selected date is May 1, 2024");
+  });
+
+  test("should use custom aria label if ariaLabel prop is set", async () => {
+    const el: DatePicker.ELEMENT = await createFixture(html`
+      <md-datepicker  value="2024-05-01" ariaLabel="Custom aria label"></md-datepicker>
+    `);
+    const input = el.shadowRoot?.querySelector("md-input");
+    expect(input).not.toBeNull();
+    expect(input?.ariaLabel).toBe("Custom aria label");
+  });
+
   test("should render with default date if we set showDefaultNowDate as true", async () => {
     const todayDate = now();
     const expectedDate = todayDate.toISO()?.slice(0, 10);

--- a/web-components/src/components/datepicker/DatePicker.ts
+++ b/web-components/src/components/datepicker/DatePicker.ts
@@ -43,6 +43,9 @@ export interface DatePickerControlButtons {
   cancel?: DatePickerControlButton;
 }
 
+const DEFAULT_ARIA_LABEL = "Choose Date";
+const DEFAULT_ARIA_LABEL_DATE_SELECTED = "Choose Date, selected date is ";
+
 export namespace DatePicker {
   export const weekStartDays = ["Sunday", "Monday"];
   const EMPTY_STRING = "";
@@ -62,7 +65,7 @@ export namespace DatePicker {
     @property({ type: Boolean }) disabled = false;
     @property({ type: String }) htmlId = "";
     @property({ type: String }) label = "";
-    @property({ type: String }) ariaLabel = "Choose Date";
+    @property({ type: String }) ariaLabel: string | null = null;
     @property({ type: Boolean }) required = false;
     @property({ type: String, reflect: true }) errorMessage = "";
     @property({ type: Boolean, attribute: "custom-trigger" }) customTrigger = false;
@@ -269,12 +272,11 @@ export namespace DatePicker {
       }
     };
 
-
-    protected getDateAriaLabel = (): string => {
+    protected getDefaultAriaLabel = (): string => {
       if (this.selectedDate && this.selectedDate.isValid) {
-        return `, selected date is ${this.selectedDate.toLocaleString(DateTime.DATE_FULL)}`;
+        return `${DEFAULT_ARIA_LABEL_DATE_SELECTED} ${this.selectedDate.toLocaleString(DateTime.DATE_FULL)}`;
       }
-      return "";
+      return DEFAULT_ARIA_LABEL;
     }
 
     private readonly getValidRegexString = (): string => {
@@ -375,7 +377,7 @@ export namespace DatePicker {
         return this.placeholder;
       }
       if (this.useISOFormat) {
-        return "YYYY/MM/DD";
+        return "YYYY-MM-DD";
       }
       return getLocaleDateFormat(this.locale ?? DateTime.local().locale).toUpperCase();
     }
@@ -392,8 +394,8 @@ export namespace DatePicker {
       }
     }
 
-    protected getAriaLabel(): string {
-      return this.ariaLabel + this.getDateAriaLabel()
+    private getAriaLabel(): string {
+      return this.ariaLabel ?? this.getDefaultAriaLabel()
     }
 
     render() {

--- a/web-components/src/components/datepicker/DatePicker.ts
+++ b/web-components/src/components/datepicker/DatePicker.ts
@@ -274,7 +274,7 @@ export namespace DatePicker {
 
     protected getDefaultAriaLabel = (): string => {
       if (this.selectedDate && this.selectedDate.isValid) {
-        return `${DEFAULT_ARIA_LABEL_DATE_SELECTED} ${this.selectedDate.toLocaleString(DateTime.DATE_FULL)}`;
+        return `${DEFAULT_ARIA_LABEL_DATE_SELECTED}${this.selectedDate.toLocaleString(DateTime.DATE_FULL)}`;
       }
       return DEFAULT_ARIA_LABEL;
     }

--- a/web-components/src/components/datepicker/scss/datepicker.scss
+++ b/web-components/src/components/datepicker/scss/datepicker.scss
@@ -206,7 +206,7 @@
         background: radial-gradient(
           circle at 50% center,
           var(--datepicker-selected-bg-color) 60%,
-          transparent 50%,
+          transparent 60%,
           var(--datepicker-range-bg-color) 60%,
           var(--datepicker-range-bg-color) 60%
         );
@@ -271,10 +271,10 @@
         &::before {                 
           background: radial-gradient(
             circle at 50% center,
-            var(--datepicker-selected-hover-bg-color) 60%,
-            rgba(0, 0, 0, 0) 60%,
-            var(--datepicker-range-bg-color) 60%,
-            var(--datepicker-range-bg-color) 60%
+            var(--datepicker-selected-hover-bg-color) 50%,
+            rgba(0, 0, 0, 0) 50%,
+            var(--datepicker-range-bg-color) 50%,
+            var(--datepicker-range-bg-color) 50%
           );  
         }
 
@@ -308,10 +308,10 @@
 
         background: radial-gradient(
           circle at 50% center,
-          var(--datepicker-selected-bg-color) 40%,
-          transparent 40%,
-          var(--datepicker-range-bg-color) 40%,
-          var(--datepicker-range-bg-color) 40%
+          var(--datepicker-selected-bg-color) 50%,
+          transparent 50%,
+          var(--datepicker-range-bg-color) 50%,
+          var(--datepicker-range-bg-color) 50%
         );
         border-bottom-right-radius: 1rem;
         border-top-right-radius: 1rem;        
@@ -343,10 +343,10 @@
         &::before {
           background: radial-gradient(
             circle at 50% center,
-            var(--datepicker-selected-bg-color) 40%,
-            rgba(0, 0, 0, 0) 40%,
-            var(--datepicker-range-bg-color) 40%,
-            var(--datepicker-range-bg-color) 40%
+            var(--datepicker-selected-bg-color) 50%,
+            transparent 50%,
+            var(--datepicker-range-bg-color) 50%,
+            var(--datepicker-range-bg-color) 50%
           );
         }
 
@@ -376,10 +376,10 @@
          &::before {                 
           background: radial-gradient(
             circle at 50% center,
-            var(--datepicker-selected-hover-bg-color) 40%,
-            rgba(0, 0, 0, 0) 40%,
-            var(--datepicker-range-bg-color) 40%,
-            var(--datepicker-range-bg-color) 40%
+            var(--datepicker-selected-hover-bg-color) 60%,
+            rgba(0, 0, 0, 0) 60%,
+            var(--datepicker-range-bg-color) 60%,
+            var(--datepicker-range-bg-color) 60%
           );  
         }
 

--- a/web-components/src/components/presence/scss/presence.scss
+++ b/web-components/src/components/presence/scss/presence.scss
@@ -12,7 +12,7 @@
     width: 0.78125rem;
     height: 0.78125rem;
     bottom: -0.03175rem;
-    right: -0.03175rem;    
+    right: -0.03175rem;
   }
 
   &[data-icon-size="13.94"] {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixes date range picker aria-lable, which before was just using what it inherited from its parent. Also added in better handling for invalid dates.

Also fixed a very minor visual bug in date-range-picker end date: 

Before:
![image](https://github.com/user-attachments/assets/799137e1-82f6-4f77-a3db-d3e5e9b7293f)

After:
![Pasted Graphic 2](https://github.com/user-attachments/assets/3e2ec642-eb7e-4088-9c1d-d1798e8087c7)

(https://jira-eng-sjc12.cisco.com/jira/browse/CX-19529)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
