### PR TITLE
chore: add badge size 36 and sentiment icon

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "2.23.12",
+  "version": "2.23.13",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/[sandbox]/examples/badge.ts
+++ b/web-components/src/[sandbox]/examples/badge.ts
@@ -1,221 +1,282 @@
 import "@/components/badge/Badge";
 import "@/components/icon/Icon";
-import { html } from "lit-element";
+import { css, customElement, html, LitElement } from "lit-element";
 
-export const badgeTemplate = html`
-  <md-badge tabIndexing="0" aria-label="my aria-label"> Default </md-badge>
-  <md-badge color="blue"> Blue </md-badge>
-  <md-badge color="red"> Red </md-badge>
-  <md-badge color="yellow"> Yellow </md-badge>
-  <md-badge color="green"> Green </md-badge>
-  <md-badge color="mint"> Mint </md-badge>
-  <md-badge color="cyan"> Cyan </md-badge>
-  <md-badge color="purple"> Purple </md-badge>
+@customElement("badge-template-sandbox")
+export class BadgeTemplateSandbox extends LitElement {
+  static get styles() {
+    return [
+      css`
+        .counter {
+          font-weight: 700;
+          flex-grow: 0;
+        }
 
-  <h4 class="sandbox-header">Additional Badges</h4>
-  <md-badge color="gray"> Gray </md-badge>
-  <md-badge color="violet"> Violet </md-badge>
-  <md-badge color="mint"> Mint </md-badge>
-  <md-badge color="gold"> Gold </md-badge>
-  <md-badge color="lime"> Lime </md-badge>
-  <md-badge color="pink"> Pink </md-badge>
-  <md-badge color="orange"> Orange </md-badge>
-  <md-badge color="cobalt"> Cobalt </md-badge>
+        .badge-text {
+          width: 112px;
+          justify-content: flex-start;
+        }
 
-  <h3 class="sandbox-header">Lumos Badges</h3>
-  <h4 class="sandbox-header">Circle Badges</h4>
+        .badge-container {
+          display: inline-flex;
+          gap: 8px;
+        }
+      `
+    ];
+  }
 
-  <md-badge color="green" circle>
-    <md-icon name="handset-active_16"></md-icon>
-  </md-badge>
-  <md-badge color="blue" circle>
-    <md-icon name="chat-active_16"></md-icon>
-  </md-badge>
-  <md-badge color="violet" circle>
-    <md-icon name="chat-active_16"></md-icon>
-  </md-badge>
-  <md-badge color="mint" circle>
-    <md-icon name="sms-filled" size="16" iconSet="momentumDesign"></md-icon>
-  </md-badge>
+  render() {
+    return html`
+      <md-badge tabIndexing="0" aria-label="my aria-label"> Default </md-badge>
+      <md-badge color="blue"> Blue </md-badge>
+      <md-badge color="red"> Red </md-badge>
+      <md-badge color="yellow"> Yellow </md-badge>
+      <md-badge color="green"> Green </md-badge>
+      <md-badge color="mint"> Mint </md-badge>
+      <md-badge color="cyan"> Cyan </md-badge>
+      <md-badge color="purple"> Purple </md-badge>
 
-  <h4 class="sandbox-header">Circle Badges with Different Sizes</h4>
+      <h4 class="sandbox-header">Additional Badges</h4>
+      <md-badge color="gray"> Gray </md-badge>
+      <md-badge color="violet"> Violet </md-badge>
+      <md-badge color="mint"> Mint </md-badge>
+      <md-badge color="gold"> Gold </md-badge>
+      <md-badge color="lime"> Lime </md-badge>
+      <md-badge color="pink"> Pink </md-badge>
+      <md-badge color="orange"> Orange </md-badge>
+      <md-badge color="cobalt"> Cobalt </md-badge>
 
-  <md-badge color="green" circle circle-size="24">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="16"></md-icon>
-  </md-badge>
-  <md-badge color="green" circle circle-size="32">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="20"></md-icon>
-  </md-badge>
-  <md-badge color="green" circle circle-size="40">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="24"></md-icon>
-  </md-badge>
-  <md-badge color="green" circle circle-size="48">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="28"></md-icon>
-  </md-badge>
-  <md-badge color="green" circle circle-size="64">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="36"></md-icon>
-  </md-badge>
-  <md-badge color="green" circle circle-size="72">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="40"></md-icon>
-  </md-badge>
-  <md-badge color="green" circle circle-size="88">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="52"></md-icon>
-  </md-badge>
-  <md-badge color="green" circle circle-size="124">
-    <md-icon name="chat-filled" iconSet="momentumDesign" size="73"></md-icon>
-  </md-badge>
+      <h3 class="sandbox-header">Lumos Badges</h3>
+      <h4 class="sandbox-header">Circle Badges</h4>
 
-  <h4 class="sandbox-header">Large Badges</h4>
-
-  <md-badge color="green">
-    <md-icon name="handset-active_16"></md-icon>
-    Voice
-    <span class="counter" style="margin:0 1rem">${"3"}</span>
-  </md-badge>
-
-  <md-badge color="blue">
-    <md-icon name="chat-active_16"></md-icon>
-    Chat
-    <span class="counter" style="margin:0 1rem">${"3"}</span>
-  </md-badge>
-
-  <md-badge color="violet">
-    <md-icon name="icon-email-active_24" size="16"></md-icon>
-    Email
-    <span class="counter" style="margin:0 1rem">${"3"}</span>
-  </md-badge>
-
-  <md-badge color="mint">
-    <md-icon name="share-c-native-adr_12" size="16"></md-icon>
-    Social
-    <span class="counter" style="margin:0 1rem">${"3"}</span>
-  </md-badge>
-
-  <md-badge color="mint" disabled>
-    <md-icon name="share-c-native-adr_12" size="16"></md-icon>
-    Disabled
-    <span class="counter" style="margin:0 1rem">${"3"}</span>
-  </md-badge>
-
-  <h4 class="sandbox-header">Small Badges</h4>
-
-  <md-badge color="mint" small>
-    <md-icon name="handset-active_12"></md-icon>
-    00:01
-  </md-badge>
-
-  <md-badge color="blue" small>
-    <md-icon name="chat-active_12"></md-icon>
-    00:01
-  </md-badge>
-
-  <md-badge color="purple" small>
-    <md-icon name="icon-email-active_24" size="12"></md-icon>
-    00:01
-  </md-badge>
-
-  <md-badge color="darkred" small>
-    <md-icon name="icon-email-active_24" size="12"></md-icon>
-    00:01
-  </md-badge>
-
-  <h4 class="sandbox-header">Split Badges</h4>
-
-  <md-badge color="mint" split>
-    <span slot="split-left">
-      <md-badge color="mint" small circle style="margin:0 .5rem 0 .375rem">
+      <md-badge color="green" circle>
         <md-icon name="handset-active_16"></md-icon>
       </md-badge>
-      ${"00:01"}
-    </span>
-    <span slot="split-right">
-      <md-icon name="headset_16" style="margin-right:.375rem;height:1rem"></md-icon>
-      ${"00:01"}
-    </span>
-  </md-badge>
-  <md-badge color="blue" split>
-    <span slot="split-left">
-      <md-badge color="blue" small circle style="margin:0 .5rem 0 .375rem">
+      <md-badge color="blue" circle>
         <md-icon name="chat-active_16"></md-icon>
       </md-badge>
-      ${"04:31"}
-    </span>
-    <span slot="split-right">
-      <md-icon name="headset_16" style="margin-right:.375rem;height:1rem"></md-icon>
-      ${"00:23"}
-    </span>
-  </md-badge>
+      <md-badge color="violet" circle>
+        <md-icon name="chat-active_16"></md-icon>
+      </md-badge>
+      <md-badge color="mint" circle>
+        <md-icon name="sms-filled" size="16" iconSet="momentumDesign"></md-icon>
+      </md-badge>
 
-  <h4 class="sandbox-header">Communications Status</h4>
+      <h4 class="sandbox-header">Circle Badges with Different Sizes</h4>
 
-  <md-badge split>
-    <span slot="split-left">
-      <md-badge color="green" circle small style="margin-right:.375rem;">
+      <md-badge color="green" circle circle-size="24">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="16"></md-icon>
+      </md-badge>
+      <md-badge color="green" circle circle-size="32">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="20"></md-icon>
+      </md-badge>
+      <md-badge color="green" circle circle-size="40">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="24"></md-icon>
+      </md-badge>
+      <md-badge color="green" circle circle-size="48">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="28"></md-icon>
+      </md-badge>
+      <md-badge color="green" circle circle-size="64">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="36"></md-icon>
+      </md-badge>
+      <md-badge color="green" circle circle-size="72">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="40"></md-icon>
+      </md-badge>
+      <md-badge color="green" circle circle-size="88">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="52"></md-icon>
+      </md-badge>
+      <md-badge color="green" circle circle-size="124">
+        <md-icon name="chat-filled" iconSet="momentumDesign" size="73"></md-icon>
+      </md-badge>
+
+      <h4 class="sandbox-header">Large Badges</h4>
+
+      <md-badge color="green">
+        <md-icon iconSet="momentumDesign" name="handset-filled" size="16"></md-icon>
+        Voice
+        <span class="counter">${"3"}</span>
+      </md-badge>
+
+      <md-badge color="blue">
+        <md-icon iconSet="momentumDesign" name="chat-filled" size="16"></md-icon>
+        Chat
+        <span class="counter">${"3"}</span>
+      </md-badge>
+
+      <md-badge color="violet">
+        <md-icon iconSet="momentumDesign" name="email-filled" size="16"></md-icon>
+        Email
+        <span class="counter">${"3"}</span>
+      </md-badge>
+
+      <md-badge color="orange">
+        <md-icon iconSet="momentumDesign" name="sms-message-filled" size="16"></md-icon>
+        Social
+        <span class="counter">${"3"}</span>
+      </md-badge>
+
+      <md-badge color="orange" disabled>
+        <md-icon iconSet="momentumDesign" name="sms-message-filled" size="16"></md-icon>
+        Disabled
+        <span class="counter">${"3"}</span>
+      </md-badge>
+
+      <h4 class="sandbox-header">Size 36</h4>
+      <div class="badge-container">
+        <md-badge class="fixed-width-badge" color="green" size="36">
+          <md-icon iconSet="momentumDesign" name="handset-filled" size="16"></md-icon>
+          <span class="badge-text">Voice</span>
+          <span class="counter">${"3"}</span>
+        </md-badge>
+
+        <md-badge class="fixed-width-badge" color="blue" size="36">
+          <md-icon iconSet="momentumDesign" name="chat-filled" size="16"></md-icon>
+          <span class="badge-text">Chat</span>
+          <span class="counter">${"3"}</span>
+        </md-badge>
+
+        <md-badge class="fixed-width-badge" color="violet" size="36">
+          <md-icon iconSet="momentumDesign" name="email-filled" size="16"></md-icon>
+          <span class="badge-text">Email</span>
+          <span class="counter">${"3"}</span>
+        </md-badge>
+
+        <md-badge class="fixed-width-badge" color="orange" size="36">
+          <md-icon iconSet="momentumDesign" name="sms-message-filled" size="16"></md-icon>
+          <span class="badge-text">Social</span>
+          <span class="counter">${"3"}</span>
+        </md-badge>
+
+        <md-badge class="fixed-width-badge" color="orange" disabled size="36">
+          <md-icon iconSet="momentumDesign" name="sms-message-filled" size="16"></md-icon>
+          <span class="badge-text">Disabled</span>
+          <span class="counter">${"3"}</span>
+        </md-badge>
+      </div>
+
+      <h4 class="sandbox-header">Small Badges</h4>
+
+      <md-badge color="mint" small>
         <md-icon name="handset-active_12"></md-icon>
+        00:01
       </md-badge>
-      ${"00:01"}
-    </span>
-    <span slot="split-right"> Wrap Up ${"00:01"} </span>
-  </md-badge>
-  <md-badge split>
-    <span slot="split-left">
-      <md-badge color="blue" circle small style="margin-right:.375rem;">
+
+      <md-badge color="blue" small>
         <md-icon name="chat-active_12"></md-icon>
+        00:01
       </md-badge>
-      ${"00:01"}
-    </span>
-    <span slot="split-right">
-      <md-icon name="headset_12" style="margin-right:.375rem;height:1rem"></md-icon>
-      Barbara Hecker ${"00:23"}
-    </span>
-  </md-badge>
 
-  <h4 class="sandbox-header">Compact Badge</h4>
-
-  <md-badge compact>
-    <span>
-      <md-badge color="blue" circle small style="margin-right:.375rem;">
-        <md-icon name="chat-active_12"></md-icon>
+      <md-badge color="purple" small>
+        <md-icon name="icon-email-active_24" size="12"></md-icon>
+        00:01
       </md-badge>
-      <span>connected - </span>
-      ${"00:01"}
-    </span>
-  </md-badge>
 
-  <h4 class="sandbox-header">Outlined Badges</h4>
+      <md-badge color="darkred" small>
+        <md-icon name="icon-email-active_24" size="12"></md-icon>
+        00:01
+      </md-badge>
 
-  <md-badge outlined> March 21, 2020 </md-badge>
-  <md-badge outlined small> March 21, 2020 </md-badge>
+      <h4 class="sandbox-header">Split Badges</h4>
 
-  <h4 class="snadbox-header">Unread count</h4>
+      <md-badge color="mint" split>
+        <span slot="split-left">
+          <md-badge color="mint" small circle style="margin:0 .5rem 0 .375rem">
+            <md-icon name="handset-active_16"></md-icon>
+          </md-badge>
+          ${"00:01"}
+        </span>
+        <span slot="split-right">
+          <md-icon name="headset_16" style="margin-right:.375rem;height:1rem"></md-icon>
+          ${"00:01"}
+        </span>
+      </md-badge>
+      <md-badge color="blue" split>
+        <span slot="split-left">
+          <md-badge color="blue" small circle style="margin:0 .5rem 0 .375rem">
+            <md-icon name="chat-active_16"></md-icon>
+          </md-badge>
+          ${"04:31"}
+        </span>
+        <span slot="split-right">
+          <md-icon name="headset_16" style="margin-right:.375rem;height:1rem"></md-icon>
+          ${"00:23"}
+        </span>
+      </md-badge>
 
-  <md-badge color="unreadcount"> 999 </md-badge>
-  <md-badge color="unreadcount"> 99 </md-badge>
-  <md-badge color="unreadcount"> 4 </md-badge>
+      <h4 class="sandbox-header">Communications Status</h4>
 
-  <md-badge color="unreadcount" outlined> 99 </md-badge>
-  <md-badge color="unreadcount" outlined> 99 </md-badge>
-  <md-badge color="unreadcount" outlined> 4 </md-badge>
+      <md-badge split>
+        <span slot="split-left">
+          <md-badge color="green" circle small style="margin-right:.375rem;">
+            <md-icon name="handset-active_12"></md-icon>
+          </md-badge>
+          ${"00:01"}
+        </span>
+        <span slot="split-right"> Wrap Up ${"00:01"} </span>
+      </md-badge>
+      <md-badge split>
+        <span slot="split-left">
+          <md-badge color="blue" circle small style="margin-right:.375rem;">
+            <md-icon name="chat-active_12"></md-icon>
+          </md-badge>
+          ${"00:01"}
+        </span>
+        <span slot="split-right">
+          <md-icon name="headset_12" style="margin-right:.375rem;height:1rem"></md-icon>
+          Barbara Hecker ${"00:23"}
+        </span>
+      </md-badge>
 
-  <h3 class="sandbox-header">status badge</h3>
-  <md-badge color="status-positive" small>
-    <md-icon name="participant-filled" iconSet="momentumDesign"></md-icon>
-    Agent name - 00:00
-  </md-badge>
-  <md-badge color="status-negative" small suppress-default-max-width>
-    <md-icon name="alert-active-filled" iconSet="momentumDesign"></md-icon>
-    %Wrap-up alert% - 00:00
-  </md-badge>
-  <md-badge color="status-accent" small>
-    <md-icon name="archive-filled" iconSet="momentumDesign"></md-icon>
-    Wrap-up - 00:00
-  </md-badge>
-  <md-badge color="status-warning" small>
-    <md-icon name="call-barge-filled" iconSet="momentumDesign"></md-icon>
-    Barged - 00:00
-  </md-badge>
-  <md-badge color="status-orange" small>
-    <md-icon name="call-hold-filled" iconSet="momentumDesign"></md-icon>
-    On hold - 00:00
-  </md-badge>
-`;
+      <h4 class="sandbox-header">Compact Badge</h4>
+
+      <md-badge compact>
+        <span>
+          <md-badge color="blue" circle small style="margin-right:.375rem;">
+            <md-icon name="chat-active_12"></md-icon>
+          </md-badge>
+          <span>connected - </span>
+          ${"00:01"}
+        </span>
+      </md-badge>
+
+      <h4 class="sandbox-header">Outlined Badges</h4>
+
+      <md-badge outlined> March 21, 2020 </md-badge>
+      <md-badge outlined small> March 21, 2020 </md-badge>
+
+      <h4 class="snadbox-header">Unread count</h4>
+
+      <md-badge color="unreadcount"> 999 </md-badge>
+      <md-badge color="unreadcount"> 99 </md-badge>
+      <md-badge color="unreadcount"> 4 </md-badge>
+
+      <md-badge color="unreadcount" outlined> 99 </md-badge>
+      <md-badge color="unreadcount" outlined> 99 </md-badge>
+      <md-badge color="unreadcount" outlined> 4 </md-badge>
+
+      <h3 class="sandbox-header">status badge</h3>
+      <md-badge color="status-positive" small>
+        <md-icon name="participant-filled" iconSet="momentumDesign"></md-icon>
+        Agent name - 00:00
+      </md-badge>
+      <md-badge color="status-negative" small suppress-default-max-width>
+        <md-icon name="alert-active-filled" iconSet="momentumDesign"></md-icon>
+        %Wrap-up alert% - 00:00
+      </md-badge>
+      <md-badge color="status-accent" small>
+        <md-icon name="archive-filled" iconSet="momentumDesign"></md-icon>
+        Wrap-up - 00:00
+      </md-badge>
+      <md-badge color="status-warning" small>
+        <md-icon name="call-barge-filled" iconSet="momentumDesign"></md-icon>
+        Barged - 00:00
+      </md-badge>
+      <md-badge color="status-orange" small>
+        <md-icon name="call-hold-filled" iconSet="momentumDesign"></md-icon>
+        On hold - 00:00
+      </md-badge>
+    `;
+  }
+}
+
+export const badgeTemplate = html` <badge-template-sandbox></badge-template-sandbox> `;

--- a/web-components/src/components/badge/Badge.ts
+++ b/web-components/src/components/badge/Badge.ts
@@ -12,11 +12,12 @@ import { html, LitElement, property } from "lit-element";
 import { nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import { ifDefined } from "lit-html/directives/if-defined";
-import { BadgeCircleSize } from "./badge.constant";
+import { BadgeCircleSize, BadgeSize } from "./badge.constant";
 import styles from "./scss/module.scss";
 
 export namespace Badge {
   export type BadgeCircleSize = (typeof BadgeCircleSize)[keyof typeof BadgeCircleSize];
+  export type BadgeSize = (typeof BadgeSize)[keyof typeof BadgeSize];
   @customElementWithCheck("md-badge")
   export class ELEMENT extends LitElement {
     @property({ type: String }) ariaLabel = "";
@@ -29,6 +30,7 @@ export namespace Badge {
     @property({ type: Boolean }) compact = false;
     @property({ type: Boolean }) circle = false;
     @property({ type: Number, attribute: "circle-size" }) circleSize: BadgeCircleSize = BadgeCircleSize[40];
+    @property({ type: Number }) size?: BadgeSize;
     @property({ type: Boolean }) small = false;
     @property({ type: Boolean }) split = false;
     @property({ type: Boolean }) disabled = false;
@@ -87,7 +89,8 @@ export namespace Badge {
         [`md-badge--circle-${this.circleSize}`]: this.circle,
         "md-badge--split": this.split,
         "md-badge--compact": this.compact,
-        "md-badge--small": this.small,
+        "md-badge--small": this.small || this.size === 24,
+        [`md-badge--size-${this.size}`]: !!this.size && this.size !== 24,
         "md-badge--outline": this.outlined,
         "md-badge--disabled": this.disabled,
         [`md-badge--${this.color}`]: !this.disabled && this.color

--- a/web-components/src/components/badge/badge.constant.ts
+++ b/web-components/src/components/badge/badge.constant.ts
@@ -1,6 +1,7 @@
 const BadgeCircleSize = {
   24: 24,
   32: 32,
+  36: 36,
   40: 40,
   48: 48,
   64: 64,
@@ -9,4 +10,10 @@ const BadgeCircleSize = {
   124: 124
 } as const;
 
-export { BadgeCircleSize };
+const BadgeSize = {
+  24: 24,
+  32: 32,
+  36: 36
+} as const;
+
+export { BadgeCircleSize, BadgeSize };

--- a/web-components/src/components/badge/scss/badge.scss
+++ b/web-components/src/components/badge/scss/badge.scss
@@ -19,6 +19,11 @@
       min-width: auto;
     }
 
+    &--size-36 {
+      height: 2.25rem;
+      padding: rem-calc(8 12 8 12);      
+    }
+
     &--compact,
     &--split {
       @include badge-size($padding: rem-calc(4 16 4 4), $text-size: var(--body-secondary, rem-calc(12)));

--- a/web-components/src/components/badge/tokens/mdv2-badge-tokens.js
+++ b/web-components/src/components/badge/tokens/mdv2-badge-tokens.js
@@ -141,23 +141,19 @@ const badge = {
   },
   violet: {
     "bg-color": {
-      light: colors.violet[20].name,
-      dark: colors.violet[70].name
+      common: "$mds-color-theme-background-label-violet-hover"
     },
     "text-color": {
-      light: colors.violet[70].name,
-      dark: colors.violet[20].name
+      common: "$mds-color-theme-text-team-violet-normal"
     },
     hover: {
       "bg-color": {
-        light: colors.violet[30].name,
-        dark: colors.violet[60].name
+        common: "$mds-color-theme-background-label-violet-hover"
       }
     },
     active: {
       "bg-color": {
-        light: colors.violet[40].name,
-        dark: colors.violet[50].name
+        common: "$mds-color-theme-background-label-violet-active"
       }
     }
   },
@@ -331,8 +327,11 @@ const badge = {
     "text-color": {
       common: "$mds-color-theme-text-primary-normal"
     },
-    "border-color": {
+    "icon-color": {
       common: "$mds-color-theme-text-success-normal"
+    },
+    "border-color": {
+      common: "$mds-color-theme-outline-join-normal"
     },
     hover: {
       "bg-color": {
@@ -352,8 +351,11 @@ const badge = {
     "text-color": {
       common: "$mds-color-theme-text-primary-normal"
     },
-    "border-color": {
+    "icon-color": {
       common: "$mds-color-theme-text-error-normal"
+    },
+    "border-color": {
+      common: "$mds-color-theme-outline-cancel-normal"
     },
     hover: {
       "bg-color": {
@@ -372,6 +374,9 @@ const badge = {
     },
     "text-color": {
       common: "$mds-color-theme-text-primary-normal"
+    },
+    "icon-color": {
+      common: "$mds-color-theme-text-secondary-normal"
     },
     "border-color": {
       common: "$mds-color-theme-outline-button-normal"

--- a/web-components/src/components/chip/scss/chip.scss
+++ b/web-components/src/components/chip/scss/chip.scss
@@ -332,6 +332,7 @@
     @include chip-sentiment-style(
       var(--badge-positive-bg-color),
       var(--badge-positive-text-color),
+      var(--badge-positive-icon-color),
       var(--badge-positive-border-color),
       var(--badge-positive-hover-bg-color),
       var(--badge-positive-active-bg-color)
@@ -342,6 +343,7 @@
     @include chip-sentiment-style(
       var(--badge-negative-bg-color),
       var(--badge-negative-text-color),
+      var(--badge-negative-icon-color),
       var(--badge-negative-border-color),
       var(--badge-negative-hover-bg-color),
       var(--badge-negative-active-bg-color)
@@ -352,6 +354,7 @@
     @include chip-sentiment-style(
       var(--badge-neutral-bg-color),
       var(--badge-neutral-text-color),
+      var(--badge-neutral-icon-color),
       var(--badge-neutral-border-color),
       var(--badge-neutral-hover-bg-color),
       var(--badge-neutral-active-bg-color)

--- a/web-components/src/components/chip/scss/mixins.scss
+++ b/web-components/src/components/chip/scss/mixins.scss
@@ -56,6 +56,7 @@
 @mixin chip-sentiment-style(
   $bg-color,
   $text-color,
+  $icon-color,
   $border-color,
   $hover-bg-color,
   $active-bg-color
@@ -68,6 +69,10 @@
   color: $text-color;
   border: 1px solid $border-color;
   border-radius: 4px;
+
+  ::slotted([slot="custom-left-content"]) {
+    color: $icon-color;
+  }
 
   &:hover {
     background-color: $hover-bg-color;
@@ -89,7 +94,7 @@
   border-radius: 12px;
 
   &:hover {
-    background-color: $bg-color;    
+    background-color: $bg-color;
   }
 
   &:active {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Badge size 36 support
Sentiment chip leading icon color

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
