### PR TITLE
CX-18767: Adding the 'Decorative' property for chip

### DIFF
--- a/web-components/src/[sandbox]/examples/chip.ts
+++ b/web-components/src/[sandbox]/examples/chip.ts
@@ -164,7 +164,7 @@ export const chipTemplate = html`
     <span slot="custom-right-content"><span aria-hidden="true"> | </span>Confidence: #####</span>
   </md-chip>
   <h3 class="sandbox-header">Agent Chip informational</h3>
-  <md-chip value="Agent: John Doe" .interactive=${false}> </md-chip>
+  <md-chip value="Agent: John Doe" decorative> </md-chip>
   <h3 class="sandbox-header">Agent Chip</h3>
   <md-chip value="Kevin Hyde" color="neutral" small>
     <md-avatar

--- a/web-components/src/components/chip/Chip.ts
+++ b/web-components/src/components/chip/Chip.ts
@@ -35,7 +35,6 @@ export namespace Chip {
     @property({ type: String }) role: Chip.Role = "group";
     @property({ type: String, reflect: true }) id = "";
     @property({ type: Boolean }) small = false;
-    @property({ type: Boolean }) interactive = true;
     @property({ type: Boolean }) readonly = false;
     @property({ type: Boolean, reflect: true }) selected = false;
     @property({ type: Boolean }) disabled = false;
@@ -45,6 +44,7 @@ export namespace Chip {
     @property({ type: String }) tooltipPlacement: Chip.Placement = "auto";
     @property({ type: String }) iconSet: Icon.IconSet | undefined = "momentumUI";
     @property({ type: Boolean, attribute: "suppress-default-max-width" }) suppressDefaultMaxWidth = false;
+    @property({ type: Boolean }) decorative = false;
 
     @property({
       type: String,
@@ -257,7 +257,7 @@ export namespace Chip {
         "suppress-max-width": this.suppressDefaultMaxWidth
       };
 
-      const ariaPressed = this.interactive || undefined;
+      const ariaPressed = !this.decorative || undefined;
 
       return html`
         ${this.getStyles()}
@@ -267,7 +267,7 @@ export namespace Chip {
           placement="${this.tooltipPlacement}"
         >
           <span
-            role=${ifDefined(this.interactive ? "button" : undefined)}
+            role=${ifDefined(!this.decorative ? "button" : undefined)}
             tabindex="0"
             class="md-chip ${classMap(classNamesInfo)}"
             part="chip"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
