### PR TITLE
feat(md-input): adding max character count info label

### DIFF
--- a/web-components/src/[sandbox]/examples/input.ts
+++ b/web-components/src/[sandbox]/examples/input.ts
@@ -103,6 +103,44 @@ export const inputTemplate = html`
         ></md-input>
       </div>
     </div>
+    <div class="row">
+      <div class="column">
+        <md-input
+          label="Normal with character count"
+          containerSize="small-12"
+          shape="pill"
+          maxLength="20"
+          displayCharacterCount
+          clear
+          autofocus
+        ></md-input>
+      </div>
+    </div>
+    <div class="row">
+      <div class="column">
+        <md-input
+          label="Multi Line with character count"
+          value="There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by ..."
+          multiline
+          containerSize="small-12"
+          shape="pill"
+          maxLength="200"
+          displayCharacterCount
+        ></md-input>
+      </div>
+      <div class="column">
+        <md-input
+          label="Multi Line ReadOnly with character count (we don't show character count if readonly)"
+          value="There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by ..."
+          multiline
+          containerSize="small-12"
+          shape="pill"
+          readOnly
+          maxLength="200"
+          displayCharacterCount
+        ></md-input>
+      </div>
+    </div>
   </section>
 
   <h3>Rectangle Shape</h3>
@@ -235,6 +273,8 @@ export const inputTemplate = html`
           .messageArr=${[{ ...messageArr, ...{ type: "error" } } as Input.Message]}
           value="Error Text"
           placeholder="Enter Text"
+          displayCharacterCount
+          maxLength="30"
         ></md-input>
       </div>
     </div>
@@ -243,6 +283,7 @@ export const inputTemplate = html`
         <md-input
           label="Error"
           containerSize="small-12"
+          maxLength="30"
           .messageArr=${[
             {
               ...messageArr,
@@ -255,6 +296,7 @@ export const inputTemplate = html`
           ]}
           value="Error Text"
           placeholder="Enter Text"
+          displayCharacterCount
         ></md-input>
       </div>
     </div>
@@ -371,6 +413,8 @@ export const inputTemplate = html`
     placeholder="Enter Text"
     secondaryLabel="Secondary Label"
     helpText="Help Text"
+    maxLength="30"
+    displayCharacterCount
   >
   </md-input>
   <md-input

--- a/web-components/src/components/input/Input.test.ts
+++ b/web-components/src/components/input/Input.test.ts
@@ -422,3 +422,100 @@ describe("Input Component", () => {
     expect(document.activeElement).not.toBe(clearButton);
   });
 });
+
+test("should display character count when maxLength and displayCharacterCount are set", async () => {
+  const maxLength = 10;
+  const value = "abc";
+  const element = await fixture<Input.ELEMENT>(
+    html`<md-input
+      label="With Character Count"
+      containerSize="small-12"
+      .maxLength=${maxLength}
+      .displayCharacterCount=${true}
+      .value=${value}
+    ></md-input>`
+  );
+
+  const characterCountLabel = element.shadowRoot!.querySelector(".md-input__character-count-label");
+  expect(characterCountLabel).not.toBeNull();
+  expect(characterCountLabel!.textContent).toBe(`${value.length}/${maxLength}`);
+});
+
+test("should not display character count if displayCharacterCount is false", async () => {
+  const element = await fixture<Input.ELEMENT>(
+    html`<md-input
+      label="No Character Count"
+      containerSize="small-12"
+      .maxLength=${10}
+      .displayCharacterCount=${false}
+      value="abc"
+    ></md-input>`
+  );
+
+  const characterCountLabel = element.shadowRoot!.querySelector(".md-input__character-count-label");
+  expect(characterCountLabel).toBeNull();
+});
+
+test("should not display character count if maxLength is not set", async () => {
+  const element = await fixture<Input.ELEMENT>(
+    html`<md-input
+      label="No Max Length"
+      containerSize="small-12"
+      .displayCharacterCount=${true}
+      value="abc"
+    ></md-input>`
+  );
+
+  const characterCountLabel = element.shadowRoot!.querySelector(".md-input__character-count-label");
+  expect(characterCountLabel).toBeNull();
+});
+
+test("should not display character count if input is disabled", async () => {
+  const element = await fixture<Input.ELEMENT>(
+    html`<md-input
+      label="Disabled"
+      containerSize="small-12"
+      .maxLength=${10}
+      .displayCharacterCount=${true}
+      value="abc"
+      disabled
+    ></md-input>`
+  );
+
+  const characterCountLabel = element.shadowRoot!.querySelector(".md-input__character-count-label");
+  expect(characterCountLabel).toBeNull();
+});
+
+test("should not display character count if input is readOnly", async () => {
+  const element = await fixture<Input.ELEMENT>(
+    html`<md-input
+      label="Read Only"
+      containerSize="small-12"
+      .maxLength=${10}
+      .displayCharacterCount=${true}
+      value="abc"
+      .readOnly=${true}
+    ></md-input>`
+  );
+
+  const characterCountLabel = element.shadowRoot!.querySelector(".md-input__character-count-label");
+  expect(characterCountLabel).toBeNull();
+});
+
+test("should display error style when value length equals maxLength", async () => {
+  const maxLength = 3;
+  const value = "abc";
+  const element = await fixture<Input.ELEMENT>(
+    html`<md-input
+      label="Error Style"
+      containerSize="small-12"
+      .maxLength=${maxLength}
+      .displayCharacterCount=${true}
+      .value=${value}
+    ></md-input>`
+  );
+
+  const errorLabel = element.shadowRoot!.querySelector(".md-input__character-count-label.error");
+  expect(errorLabel).not.toBeNull();
+  expect(errorLabel!.textContent).toBe(`${value.length}/${maxLength}`);
+});

--- a/web-components/src/components/input/Input.ts
+++ b/web-components/src/components/input/Input.ts
@@ -218,6 +218,7 @@ export namespace Input {
     @property({ type: Boolean }) showDropdown = false;
     @property({ type: Boolean }) dropdownExpanded = false;
     @property({ type: String }) dropdownAriaLabel = "Show options";
+    @property({ type: Boolean }) displayCharacterCount = false;
 
     @query(".md-input") input!: HTMLInputElement;
 
@@ -612,6 +613,16 @@ export namespace Input {
         : nothing;
     }
 
+    private characterCountTemplate() {
+      return this.maxLength && this.displayCharacterCount && !this.disabled && !this.readOnly
+        ? html`<div style="padding-top: 18px; flex: none;">
+            <span class="md-input__character-count-label ${classMap({ error: this.value.length >= this.maxLength })}"
+              >${this.value.length}/${this.maxLength}</span
+            >
+          </div> `
+        : nothing;
+    }
+
     secondaryLabelTemplate() {
       return this.secondaryLabel
         ? html`
@@ -681,7 +692,12 @@ export namespace Input {
           <div class="md-input__wrapper ${classMap(this.inputWrapperClassMap)}">
             ${this.inputLeftTemplate()} ${this.inputTemplate()} ${this.inputRightTemplate()}
           </div>
-          ${this.messagesTemplate()} ${this.secondaryLabelTemplate()} ${this.helpTextTemplate()}
+          <div style="display: flex; justify-content: space-between; align-items: flex-start;">
+            <div style="flex: 1 1 auto;">
+              ${this.messagesTemplate()} ${this.secondaryLabelTemplate()} ${this.helpTextTemplate()}
+            </div>
+            ${this.characterCountTemplate()}
+          </div>
         </div>
       `;
     }

--- a/web-components/src/wc_scss/tools/mixins/input.scss
+++ b/web-components/src/wc_scss/tools/mixins/input.scss
@@ -128,6 +128,13 @@
   .md-input__secondary-label {
     color: $color-help;
   }
+
+  .md-input__character-count-label {
+    color: var(--label-secondary);
+    &.error {
+      color: var(--input-error-message-text-color);
+    }
+  }
 }
 
 @mixin input-icon($color: null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
