### PR TITLE
CX-23183 : Sign In: Screen Reader: Country code listbox incorrectly implemented as a list with listitems 

### DIFF
--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -1688,7 +1688,7 @@ export namespace ComboBox {
           class="md-combobox-option"
           aria-posinset=${count}
           aria-setsize=${total}
-          role=${this.isMulti ? "checkbox" : "listitem"}
+          role=${this.isMulti ? "checkbox" : "option"}
           aria-label="${this.isCustomContent
             ? this.getOptionId(option)
             : this.getOptionValue(option)}${ariaLabelForCount}"
@@ -1854,7 +1854,7 @@ export namespace ComboBox {
                   part="combobox-options"
                   aria-label=${this.ariaLabel || this.label}
                   style=${this.addStyle()}
-                  role=${ifDefined(this.checkForVirtualScroll() ? undefined : "list")}
+                  role=${ifDefined(this.checkForVirtualScroll() ? undefined : "listbox")}
                 >
                   ${this.isMulti && this.allowSelectAll && this.expanded ? this.getSelectAllOption() : nothing}
                   ${!this.checkForVirtualScroll()


### PR DESCRIPTION
## Description
Updated the ARIA role attribute from role="list" to role="listbox" and Changed role="listitem" to role="option" to match the WAI-ARIA Authoring Practices for a Listbox.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
For Accessibility Issue fix

## How Has This Been Tested?
Reported scenario has been tested as per the Accessibility steps and it is working as expected.

## Screenshots:
**Before** (If applicable):
<img width="827" height="452" alt="image" src="https://github.com/user-attachments/assets/a00b0694-627f-4a80-8a8c-e9b5b6881229" />

**After**:
<img width="961" height="517" alt="image" src="https://github.com/user-attachments/assets/84ab25bd-f849-451c-929f-296f1754aeb8" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
