### PR TITLE
feat(chip): make chip focusability configurable

### DIFF
--- a/web-components/src/[sandbox]/examples/chip.ts
+++ b/web-components/src/[sandbox]/examples/chip.ts
@@ -16,6 +16,19 @@ export const chipTemplate = html`
   <md-chip value="Cobalt" color="cobalt"> </md-chip>
   <h3 class="sandbox-header">Read Only Default Chip</h3>
   <md-chip value="developer@cisco.ninja" readonly> </md-chip>
+  <h3 class="sandbox-header">Focusable Chip</h3>
+  <md-chip value="Focusable chip"> </md-chip>
+  <md-chip .focusable=${false} value="Non-focusable chip">
+    <md-icon
+      name="cancel-bold"
+      iconSet="momentumDesign"
+      tabIndex="0"
+      role="button"
+      aria-label="Remove non-focusable chip"
+      slot="custom-right-content"
+    >
+    </md-icon>
+  </md-chip>
   <h3 class="sandbox-header">Selected Chip</h3>
   <md-chip
     icon="file-pdf-bold"

--- a/web-components/src/components/chip/Chip.test.ts
+++ b/web-components/src/components/chip/Chip.test.ts
@@ -88,6 +88,25 @@ describe("Chip component", () => {
     expect(component.disabled).toBeTruthy();
   });
 
+  test("should allow slotted controls to remain tabbable when chip is not focusable", async () => {
+    const component: Chip.ELEMENT = await fixture(html`
+      <md-chip .focusable=${false} value="Non-focusable chip">
+        <md-icon
+          name="cancel-bold"
+          iconSet="momentumDesign"
+          tabIndex="0"
+          role="button"
+          slot="custom-right-content"
+        ></md-icon>
+      </md-chip>
+    `);
+    const chip = component.shadowRoot?.querySelector(".md-chip") as HTMLElement;
+    const icon = component.querySelector("md-icon") as HTMLElement;
+
+    expect(chip.hasAttribute("tabindex")).toBeFalsy();
+    expect(icon.tabIndex).toEqual(0);
+  });
+
   test("should handleClear", async () => {
     const component = await fixtureFactory();
     const spyKeyDown = jest.spyOn(component, "handleClear");

--- a/web-components/src/components/chip/Chip.ts
+++ b/web-components/src/components/chip/Chip.ts
@@ -46,6 +46,7 @@ export namespace Chip {
     @property({ type: Boolean, attribute: "suppress-default-max-width" }) suppressDefaultMaxWidth = false;
     @property({ type: Boolean }) decorative = false;
     @property({ type: Boolean }) shouldTruncateValue = true;
+    @property({ type: Boolean }) focusable = true;
 
     @property({
       type: String,
@@ -319,7 +320,7 @@ export namespace Chip {
         >
           <span
             role=${ifDefined(!this.decorative ? "button" : undefined)}
-            tabindex="0"
+            tabindex=${ifDefined(this.focusable ? "0" : undefined)}
             class="md-chip ${classMap(classNamesInfo)}"
             part="chip"
             aria-pressed=${ifDefined(ariaPressed)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
make chip focusability configurable, so we can propagate focus to the button by default.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accesibility

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Sandbox example works as expected

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
