### PR TITLE
CX-22858: Sign In: JAWS: Icon next to error message announced as "icon" by the screen reader

### DIFF
--- a/web-components/src/components/help-text/HelpText.test.ts
+++ b/web-components/src/components/help-text/HelpText.test.ts
@@ -1,5 +1,6 @@
 import { elementUpdated, fixture, fixtureCleanup } from "@open-wc/testing-helpers";
 import { html } from "lit";
+import "../icon/Icon";
 import "./HelpText";
 import { HelpText } from "./HelpText";
 
@@ -34,5 +35,36 @@ describe("TextHelper component", () => {
     element.messageType = "priority";
     await elementUpdated(element);
     expect(element.shadowRoot!.querySelector("md-icon")!.getAttribute("name")).toEqual("info-badge-filled");
+  });
+
+  test("should hide status icons from assistive technologies for all message types", async () => {
+    const messageTypes: Array<{ type: HelpText.ELEMENT["messageType"]; iconName: string }> = [
+      { type: "error", iconName: "error-legacy-badge-filled" },
+      { type: "success", iconName: "check-circle-badge-filled" },
+      { type: "warning", iconName: "warning-badge-filled" },
+      { type: "priority", iconName: "info-badge-filled" }
+    ];
+
+    for (const { type, iconName } of messageTypes) {
+      element.messageType = type;
+      element.message = `${type} message`;
+      await elementUpdated(element);
+
+      const icon = element.shadowRoot!.querySelector("md-icon") as HTMLElement & { ariaHidden?: string };
+      expect(icon).not.toBeNull();
+      expect(icon.getAttribute("name")).toEqual(iconName);
+      expect(icon.ariaHidden).toEqual("true");
+
+      await elementUpdated(icon);
+      expect(icon.shadowRoot?.querySelector(".svg-icon-container")?.getAttribute("aria-hidden")).toEqual("true");
+    }
+  });
+
+  test("should not render a status icon when message type is not set", async () => {
+    element.message = "Help text without icon";
+    element.messageType = undefined;
+    await elementUpdated(element);
+
+    expect(element.shadowRoot!.querySelector("md-icon")).toBeNull();
   });
 });

--- a/web-components/src/components/help-text/HelpText.ts
+++ b/web-components/src/components/help-text/HelpText.ts
@@ -56,7 +56,12 @@ export namespace HelpText {
           role="alert"
         >
           ${this.messageType
-            ? html`<md-icon name="${this.getIconName()}" size="14" iconSet="momentumDesign"></md-icon>`
+            ? html`<md-icon
+                name="${this.getIconName()}"
+                size="14"
+                iconSet="momentumDesign"
+                ariaHidden="true"
+              ></md-icon>`
             : nothing}
           <slot>${this.message}</slot>
         </div>

--- a/web-components/src/components/input/Input.test.ts
+++ b/web-components/src/components/input/Input.test.ts
@@ -306,6 +306,10 @@ describe("Input Component", () => {
     const inputMessageElement = querySelectorAllDeep("md-help-text");
     expect(messagesSpy).toHaveReturnedWith(["This is where the error message would be."]);
     expect(inputMessageElement.length).toBeGreaterThan(0);
+
+    const errorIcon = querySelectorDeep("md-help-text md-icon") as HTMLElement & { ariaHidden?: string };
+    expect(errorIcon).not.toBeNull();
+    expect(errorIcon.ariaHidden).toEqual("true");
   });
 
   test("should render multiline", async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
CX-22858: Sign In: JAWS: Icon next to error message announced as "icon" by the screen reader
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->
Sign_In-JAWS-Icon_next_to_error_message_announced_as_icon_by_the_screen_reader.png: https://platform.applause.com/services/links/v1/external/7893913b4f24f4e6e7138152a3e5154ee710f858b5664a69d9cabb239eb6cfac
1-Other_Occurences-Agent_profile_Profile_settings_dialog.png: https://platform.applause.com/services/links/v1/external/6b6e7958bc86cabfc152bf1f617a7214f60ee853d8633cf5a622383faa52d5cd
2-Other_Occurrences-Header_Outdial_call_buttonDialpad_tabEnter_one_or_two_digit_numbers_inEnter_a_number_to_dialinputError_icon_X_is_announced_confusingly_asicon.png: https://platform.applause.com/services/links/v1/external/8bd8ad84bf5a67fc9a15fa27497022fba0f5a6392b0777efa26aeb578fe4392d
3-Other_Occurrences-Header__New_outbound_conversationbuttonEmail_tab_ToinputError_icon_X_is_announced_confusingly_asicon.png: https://platform.applause.com/services/links/v1/external/51a12d230cbafb5e58a4c6d7000b6b1082c8569fe15a0eb223691bba8776d922
4-Other_Occurrences-Header__New_outbound_conversationbuttonSMS_tab_ToinputError_icon_X_is_announced_confusingly_asicon.png: https://platform.applause.com/services/links/v1/external/f60eba4129b9d00bf729401ca7abd15511ffbc2e1086b53775e20f37a731c0da
Sign_In-JAWS-Icon_next_to_error_message_announced_as_icon_by_the_screen_reader.mp4: https://platform.applause.com/services/links/v1/external/80d02d0c1bbcd4ed1569e41a48f2a9e6ecedab9240e31b3d0846a1d2244748bd
**After**:
<!--- Please add after images, gifs or videos here: -->
Please refer below vidcast video: 
https://app.vidcast.io/share/39eb9910-2810-43e6-b728-775fb61ea5f3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
