### PR TITLE
CX-23080: Sign In: Screen Reader: Country code listbox selected option does not announce selected state.

### DIFF
--- a/web-components/src/components/combobox/ComboBox.test.ts
+++ b/web-components/src/components/combobox/ComboBox.test.ts
@@ -876,6 +876,66 @@ describe("Combobox Component", () => {
       expect(el.selectedOptions.length).toEqual(1);
       expect(el.selectedOptions).toEqual(expect.arrayContaining(["Afghanistan"]));
     });
+
+    test("should announce selected state on the selected single-select option via aria-selected", async () => {
+      const el = await fixture<ComboBox.ELEMENT>(html` <md-combobox .options=${comboBoxOptions}></md-combobox> `);
+      el.expanded = true;
+      await elementUpdated(el);
+
+      // Single-select options expose aria-selected so screen readers announce state.
+      expect(el.lists![0].getAttribute("role")).toEqual("option");
+
+      // No option should be marked selected before a selection is made.
+      [...el.lists!].forEach((option) => {
+        expect(option.getAttribute("aria-selected")).toEqual("false");
+      });
+
+      el.selectedOptions = [comboBoxOptions[0]];
+      await elementUpdated(el);
+
+      // The chosen option is announced as selected, others are not.
+      expect(el.lists![0].getAttribute("aria-selected")).toEqual("true");
+      expect(el.lists![1].getAttribute("aria-selected")).toEqual("false");
+    });
+
+    test("should announce selected state for custom-content (slotted) single-select option", async () => {
+      // Mirrors the country-code-picker: single-select combobox with slotted custom content.
+      const el = await fixture<ComboBox.ELEMENT>(html`
+        <md-combobox with-custom-content>
+          ${repeat(
+            comboBoxComplexObjectOption,
+            (country) => country.countryNameEn,
+            (country: { countryNameEn: string; countryCallingCode: string }, index) => html`
+              <div
+                slot=${index}
+                display-value=${country.countryNameEn}
+                aria-label="+${country.countryCallingCode}${country.countryNameEn}"
+              >
+                <span>${country.countryNameEn}</span>
+                <span>+${country.countryCallingCode}</span>
+              </div>
+            `
+          )}
+        </md-combobox>
+      `);
+
+      el.expanded = true;
+      await elementUpdated(el);
+
+      // Each slotted option is a listbox option with an explicit (false) selected state.
+      expect(el.lists![0].getAttribute("role")).toEqual("option");
+      [...el.lists!].forEach((option) => {
+        expect(option.getAttribute("aria-selected")).toEqual("false");
+      });
+
+      el.selectedOptions = [el.options[0]];
+      await elementUpdated(el);
+
+      // The active/selected slotted option announces its selected state.
+      expect(el.lists![0].getAttribute("role")).toEqual("option");
+      expect(el.lists![0].getAttribute("aria-selected")).toEqual("true");
+      expect(el.lists![1].getAttribute("aria-selected")).toEqual("false");
+    });
   });
 
   test("should set initial value", async () => {

--- a/web-components/src/components/combobox/ComboBox.ts
+++ b/web-components/src/components/combobox/ComboBox.ts
@@ -1702,6 +1702,7 @@ export namespace ComboBox {
           tabindex="-1"
           @click=${(event: MouseEvent) => this.handleListClick(event)}
           aria-checked=${ifDefined(this.isMulti ? this.isOptionChecked.call(this, option) : undefined)}
+          aria-selected=${ifDefined(this.isMulti ? undefined : this.isOptionChecked.call(this, option))}
         >
           ${this.isMulti
             ? html`

--- a/web-components/src/components/country-code-picker/CountryCodePicker.test.ts
+++ b/web-components/src/components/country-code-picker/CountryCodePicker.test.ts
@@ -73,6 +73,32 @@ describe("CountryCodePicker Component", () => {
     expect(element.countryCallingCode).toEqual("");
   });
 
+  test("should mark the selected country option with aria-selected so screen readers announce it", async () => {
+    const element = await fixture<CountryCodePicker.ELEMENT>(html`
+      <md-country-code-picker .countryCallingCode=${"+376, Andorra, AD"}></md-country-code-picker>
+    `);
+    await elementUpdated(element);
+    const combobox = element.shadowRoot!.querySelector("md-combobox") as HTMLElement & {
+      expanded: boolean;
+    };
+    combobox.expanded = true;
+    await elementUpdated(combobox);
+    jest.advanceTimersByTime(600);
+    await elementUpdated(combobox);
+
+    const options = [...combobox.shadowRoot!.querySelectorAll(".md-combobox-option")];
+    const selected = combobox.shadowRoot!.querySelector('.md-combobox-option[aria-selected="true"]');
+
+    expect(selected).not.toBeNull();
+    expect(selected!.getAttribute("role")).toEqual("option");
+    expect(selected!.id).toEqual("+376, Andorra, AD");
+    // Every option exposes an explicit selected state; only the chosen one is true.
+    options.forEach((option) => {
+      expect(option.getAttribute("role")).toEqual("option");
+      expect(option.getAttribute("aria-selected")).toEqual(option === selected ? "true" : "false");
+    });
+  });
+
   test("Should render a flag image when show-flags is true", async () => {
     const element = await fixture<CountryCodePicker.ELEMENT>(
       html`<md-country-code-picker show-flags></md-country-code-picker>`


### PR DESCRIPTION
Country code listbox selected option does not announce selected state by the screen reader in Mac OS

## Description
Single-select combobox options (e.g. the country code picker in the station login dialog) only exposed role="option" without aria-selected, so screen readers announced the active option without its selected state. Add aria-selected (true on the chosen option, false on the rest) so assistive tech announces the selection, and cover it with combobox and country-code-picker regression tests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
