### PR TITLE
fix(datepicker): Fix styling for selected ranges when high contrast mode is enabled

### DIFF
--- a/web-components/src/components/datepicker/scss/datepicker.scss
+++ b/web-components/src/components/datepicker/scss/datepicker.scss
@@ -535,10 +535,4 @@ md-input::part(md-input-container) {
       left: -0.125rem;
     }
   }
-
-  .md-datepicker__day--start-date::part(button):focus,
-  .md-datepicker__day--end-date::part(button):focus {
-    // Endpoints already provide an offset focus ring through ::after.
-    outline: none;
-  }
 }

--- a/web-components/src/components/datepicker/scss/datepicker.scss
+++ b/web-components/src/components/datepicker/scss/datepicker.scss
@@ -489,3 +489,56 @@
 md-input::part(md-input-container) {
   margin-bottom: 0.5rem;
 }
+
+@media (forced-colors: active) {
+  .md-datepicker__day--selected::part(button),
+  .md-datepicker__day--in-range::part(button) {
+    --datepicker-selected-bg-color: SelectedItem;
+    --datepicker-selected-hover-bg-color: SelectedItem;
+    --datepicker-selected-pressed-bg-color: SelectedItem;
+    --datepicker-selected-text-color: SelectedItemText;
+    --datepicker-selected-today-border: 1px solid currentColor;
+    --datepicker-range-bg-color: Highlight;
+    --datepicker-range-edge-bg-color: SelectedItem;
+    --datepicker-range-hover-bg-color: Highlight;
+    --datepicker-range-text-color: HighlightText;
+    --datepicker-pressed-text-color: HighlightText;
+    --button-focus-ring-color: Highlight;
+
+    forced-color-adjust: none;
+  }
+
+  .md-datepicker__day--in-range:not(.md-datepicker__day--start-date):not(.md-datepicker__day--end-date) {
+    &::part(button)::before {
+      // The centered range pseudo-elements normally overlap by 1px.
+      // Match the 32px button plus 4px column gap exactly in forced-colors mode.
+      width: calc(#{$day-button-height} + 0.25rem);
+    }
+
+    // The general forced-colors rule overrides the normal first-column width.
+    // Restore the half-gap extension so it meets the next range segment and no gap is shown in background
+    &.md-datepicker__day--week-first::part(button)::before {
+      width: calc(#{$day-button-height} + 0.125rem);
+    }
+
+    // Extend the last cell in the row halfway into the preceding gap so it meets the
+    // previous range segment without using the normal overlapping geometry.
+    &.md-datepicker__day--week-last::part(button)::before {
+      left: -0.125rem;
+      width: calc(#{$day-button-height} + 0.125rem);
+    }
+  }
+
+  .md-datepicker__day--end-date:not(.md-datepicker__day--start-date):not(.md-datepicker__day--week-first) {
+    &::part(button)::before {
+      // Meet the preceding connector halfway across the column gap.
+      left: -0.125rem;
+    }
+  }
+
+  .md-datepicker__day--start-date::part(button):focus,
+  .md-datepicker__day--end-date::part(button):focus {
+    // Endpoints already provide an offset focus ring through ::after.
+    outline: none;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When high contrast mode is enabled (tested by myself on macos with edge using "night sky" page colours enabled) the selected

When viewing the date range picker on high contrast the highlights for the selected range weren't showing properly (the start and end dates and the intermediary dates). This PR adds specific styling when [forced colors](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/forced-colors) is enabled

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->
| Normal 12th-18th July Selected   |   Normal 12th - 19th July Selected | Normal 14th July Selected |
| --- | --- | --- |
|  <img width="285" height="374" alt="Screenshot 2026-07-24 at 10 00 34" src="https://github.com/user-attachments/assets/6a2ade00-b788-4141-be31-50db288f1f0f" />  |  <img width="281" height="374" alt="Screenshot 2026-07-24 at 10 00 43" src="https://github.com/user-attachments/assets/58126ff9-d47a-407f-b1e5-1c36960396fb" />  | <img width="293" height="381" alt="Screenshot 2026-07-24 at 10 00 45" src="https://github.com/user-attachments/assets/08a9080f-616a-4955-aa64-bb21a9dbc0da" />   |

| High contrast 12th-18th July Selected   |   High contrast 12th - 19th July Selected | High contrast 14th July Selected |
| --- | --- | --- |
| <img width="289" height="372" alt="Screenshot 2026-07-24 at 09 59 56" src="https://github.com/user-attachments/assets/e6b340ec-6875-48de-b3f2-369aa989738b" />   |  <img width="284" height="379" alt="Screenshot 2026-07-24 at 10 00 02" src="https://github.com/user-attachments/assets/bdda0b1f-3155-4af3-af47-f742eae45586" />   |  <img width="292" height="375" alt="Screenshot 2026-07-24 at 10 00 14" src="https://github.com/user-attachments/assets/77d127a6-b44c-44b4-bf1e-05a2e6cb3acb" />  |

**After**:
<!--- Please add after images, gifs or videos here: -->

| High contrast 12th-18th July Selected   |   High contrast 12th - 19th July Selected | High contrast 14th July Selected |
| --- | --- | --- |
| <img width="286" height="379" alt="Screenshot 2026-07-24 at 09 58 43" src="https://github.com/user-attachments/assets/63397d89-4ffa-46db-9b52-8834d67c270c" />   |  <img width="280" height="376" alt="Screenshot 2026-07-24 at 09 58 54" src="https://github.com/user-attachments/assets/95b976b6-7381-4972-b825-a629664dfaa1" />   |  <img width="289" height="376" alt="Screenshot 2026-07-24 at 09 59 02" src="https://github.com/user-attachments/assets/64c87a36-f658-41cf-86f6-ea227ad66098" />  |



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
