### PR TITLE
fix(md-input): reserve space for empty dropdown controls

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "3.2.23",
+  "version": "3.2.24",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/components/input/Input.stories.ts
+++ b/web-components/src/components/input/Input.stories.ts
@@ -251,6 +251,78 @@ export const NewMomentumMessages: StoryObj = {
   }
 };
 
+export const DropdownEndControlSpacing: StoryObj = {
+  render: () => html`
+    <style>
+      .dropdown-spacing-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(176.5px, max-content));
+      }
+
+      .dropdown-spacing-case {
+        width: 176.5px;
+      }
+
+      .dropdown-spacing-case p {
+        font-size: 0.75rem;
+        line-height: 1rem;
+        margin: 0 0 0.5rem;
+      }
+    </style>
+
+    <div class="dropdown-spacing-grid">
+      <div class="dropdown-spacing-case">
+        <p>Empty searchable dropdown</p>
+        <md-input newMomentum searchable clear showDropdown placeholder="Sélectionner une ressource"></md-input>
+      </div>
+
+      <div class="dropdown-spacing-case">
+        <p>Dirty clear and dropdown</p>
+        <md-input newMomentum clear showDropdown value="Selected resource"></md-input>
+      </div>
+
+      <div class="dropdown-spacing-case">
+        <p>Empty compact dropdown</p>
+        <md-input newMomentum compact showDropdown placeholder="Sélectionner une ressource"></md-input>
+      </div>
+
+      <div class="dropdown-spacing-case">
+        <p>Empty disabled dropdown</p>
+        <md-input newMomentum disabled showDropdown placeholder="Sélectionner une ressource"></md-input>
+      </div>
+
+      <div class="dropdown-spacing-case">
+        <p>Empty read-only dropdown</p>
+        <md-input newMomentum readOnly showDropdown placeholder="Sélectionner une ressource"></md-input>
+      </div>
+
+      <div class="dropdown-spacing-case">
+        <p>Empty multiline dropdown</p>
+        <md-input newMomentum multiline showDropdown placeholder="Sélectionner une ressource"></md-input>
+      </div>
+
+      <div class="dropdown-spacing-case" dir="rtl">
+        <p>Empty RTL dropdown</p>
+        <md-input newMomentum searchable showDropdown placeholder="Sélectionner une ressource"></md-input>
+      </div>
+
+      <div class="dropdown-spacing-case">
+        <p>Empty legacy dropdown</p>
+        <md-input searchable showDropdown placeholder="Sélectionner une ressource"></md-input>
+      </div>
+    </div>
+  `,
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "Fixed-width visual regression cases for the inline-end space reserved by a rendered dropdown control."
+      }
+    }
+  }
+};
+
 const meta: Meta = {
   title: "Components/Input",
   component: "md-input",

--- a/web-components/src/components/input/scss/input.scss
+++ b/web-components/src/components/input/scss/input.scss
@@ -518,6 +518,10 @@
     transition: box-shadow ease-out 0.15s;
     width: 100%;
 
+    &:not(.md-input--multiline):has(~ .md-input__after > .md-input__dropdown-button) {
+      padding-inline-end: $input__padding-side--icon;
+    }
+
     &.md-dirty {
       padding-inline-end: rem-calc(8);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes md-input placeholders overlapping the dropdown button when the input is empty. Single-line dropdown inputs now always reserve 32 px for the rendered end control, while existing clear-button, multiline, RTL, and dirty-state spacing remains unchanged. Adds a fixed-width Storybook regression matrix covering the affected states.



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
<img width="780" height="640" alt="obraz" src="https://github.com/user-attachments/assets/0de7a623-f1ac-4090-912a-cdd4d349aa43" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
