### PR TITLE
#CX-23077 : Sign In: Color Contrast: Selected state indicator (grey background) fails color contrast ratio

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/web-components",
-  "version": "3.2.24",
+  "version": "3.2.25",
   "author": "Yana Harris",
   "license": "MIT",
   "repository": "https://github.com/momentum-design/momentum-ui.git",

--- a/web-components/src/[sandbox]/examples/AdvanceList/components/ParentComponentPreSelect.ts
+++ b/web-components/src/[sandbox]/examples/AdvanceList/components/ParentComponentPreSelect.ts
@@ -41,9 +41,7 @@ export namespace ParentComponentPreSelect {
         this.totalRecords = 60000;
         this.page += 1;
         this.isLoading = false;
-        // Assign a new array reference (not push) so Lit's dirty-check detects the
-        // change and md-advance-list applies the preselected state.
-        this.value = [this.items[1].id];
+        this.value.push(this.items[1].id);
       } catch (_err) {
         this.isLoading = false;
         this.isError = true;

--- a/web-components/src/[sandbox]/examples/AdvanceList/components/ParentComponentPreSelect.ts
+++ b/web-components/src/[sandbox]/examples/AdvanceList/components/ParentComponentPreSelect.ts
@@ -41,7 +41,9 @@ export namespace ParentComponentPreSelect {
         this.totalRecords = 60000;
         this.page += 1;
         this.isLoading = false;
-        this.value.push(this.items[1].id);
+        // Assign a new array reference (not push) so Lit's dirty-check detects the
+        // change and md-advance-list applies the preselected state.
+        this.value = [this.items[1].id];
       } catch (_err) {
         this.isLoading = false;
         this.isError = true;

--- a/web-components/src/[sandbox]/examples/list.ts
+++ b/web-components/src/[sandbox]/examples/list.ts
@@ -3,6 +3,13 @@ import "@/components/list/ListItem";
 import { html } from "lit";
 
 export const listTemplate = html`
+  <h3>Selected (WCAG 1.4.11 &ndash; selected label must be BOLD)</h3>
+  <div style="width: 280px; border: 1px solid #ccc; padding: 4px;">
+    <md-list-item aria-label="Neptunium" role="option">Neptunium (normal)</md-list-item>
+    <md-list-item aria-label="Americium selected" role="option" selected>Americium (selected &rarr; bold)</md-list-item>
+    <md-list-item aria-label="Curium" role="option">Curium (normal)</md-list-item>
+  </div>
+
   <h3>Default</h3>
   <md-list label="Transuranium elements">
     <md-list-item aria-label="Neptunium" slot="list-item">Neptunium</md-list-item>

--- a/web-components/src/components/advance-list/scss/AdvanceList.scss
+++ b/web-components/src/components/advance-list/scss/AdvanceList.scss
@@ -45,8 +45,13 @@
   color: var(--list-active-text-color);
 }
 
-// Bold the selected row label as a non-color cue (skip non-selectable rows).
-.default-wrapper.selected:not(.non-selectable) {
+// The selected background alone fails WCAG 2.1 SC 1.4.11 (non-text contrast,
+// 3:1), so bold the selected row label as a non-color cue (skip non-selectable
+// rows). The label is rendered inside this shadow tree (not slotted), so the
+// reset stylesheet pins its font-weight and breaks inheritance from the wrapper
+// — target the descendants explicitly so the actual label text goes bold.
+.default-wrapper.selected:not(.non-selectable),
+.default-wrapper.selected:not(.non-selectable) * {
   font-weight: var(--list-selected-font-weight, bold);
 }
 

--- a/web-components/src/components/advance-list/scss/AdvanceList.scss
+++ b/web-components/src/components/advance-list/scss/AdvanceList.scss
@@ -45,11 +45,6 @@
   color: var(--list-active-text-color);
 }
 
-// The selected background alone fails WCAG 2.1 SC 1.4.11 (non-text contrast,
-// 3:1), so bold the selected row label as a non-color cue (skip non-selectable
-// rows). The label is rendered inside this shadow tree (not slotted), so the
-// reset stylesheet pins its font-weight and breaks inheritance from the wrapper
-// — target the descendants explicitly so the actual label text goes bold.
 .default-wrapper.selected:not(.non-selectable),
 .default-wrapper.selected:not(.non-selectable) * {
   font-weight: var(--list-selected-font-weight, bold);

--- a/web-components/src/components/advance-list/scss/AdvanceList.scss
+++ b/web-components/src/components/advance-list/scss/AdvanceList.scss
@@ -45,6 +45,11 @@
   color: var(--list-active-text-color);
 }
 
+// Bold the selected row label as a non-color cue (skip non-selectable rows).
+.default-wrapper.selected:not(.non-selectable) {
+  font-weight: var(--list-selected-font-weight, bold);
+}
+
 .default-wrapper.focused {
   outline: 2px solid var(--md-default-focus-outline-color);
   outline-offset: -2px;

--- a/web-components/src/components/combobox/scss/combobox.scss
+++ b/web-components/src/components/combobox/scss/combobox.scss
@@ -523,6 +523,11 @@ div#md-combobox-listbox {
     .select-option {
       border: 1px solid #fff;
     }
+
+    // convey the selected state with a non-color cue by bolding the label
+    .select-label {
+      font-weight: $font-weight-bold;
+    }
   }
 }
 

--- a/web-components/src/components/list/scss/listitem.scss
+++ b/web-components/src/components/list/scss/listitem.scss
@@ -45,8 +45,13 @@
   }
 }
 
-// Add a bold label as a non-color cue for the persistently selected option.
+// The selected background alone fails WCAG 2.1 SC 1.4.11 (non-text contrast, 3:1),
+// so add a bold label as a non-color cue. Applied on :host so a raw slotted
+// text-node label (whose light-DOM parent is the host) inherits the weight; the
+// inner rule also covers content rendered inside the shadow wrapper.
 :host([selected]:not([disabled])) {
+  font-weight: var(--list-selected-font-weight, bold);
+
   .md-list-item {
     font-weight: var(--list-selected-font-weight, bold);
   }

--- a/web-components/src/components/list/scss/listitem.scss
+++ b/web-components/src/components/list/scss/listitem.scss
@@ -45,6 +45,13 @@
   }
 }
 
+// Add a bold label as a non-color cue for the persistently selected option.
+:host([selected]:not([disabled])) {
+  .md-list-item {
+    font-weight: var(--list-selected-font-weight, bold);
+  }
+}
+
 :host([focus-visible]) {
   .md-list-item {
     box-shadow: $list-item__focus-shadow;

--- a/web-components/src/components/list/scss/listitem.scss
+++ b/web-components/src/components/list/scss/listitem.scss
@@ -45,10 +45,6 @@
   }
 }
 
-// The selected background alone fails WCAG 2.1 SC 1.4.11 (non-text contrast, 3:1),
-// so add a bold label as a non-color cue. Applied on :host so a raw slotted
-// text-node label (whose light-DOM parent is the host) inherits the weight; the
-// inner rule also covers content rendered inside the shadow wrapper.
 :host([selected]:not([disabled])) {
   font-weight: var(--list-selected-font-weight, bold);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
